### PR TITLE
Link to project docs for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,18 @@
 Requires solc 0.4.23 or later, go 1.9.2 or later
 
 First we need some external tooling:
+
 1. Solidity:
-```bash
-brew tap ethereum/ethereum
-brew install solidity
-```
+
+See the Solidity docs for installation instructions:
+
+ https://solidity.readthedocs.io/en/v0.4.24/installing-solidity.html
+
 2. Ethereum (geth, abigen):
-```bash
-brew install ethereum
-```
+
+See the Ethereum docs for installation instructions:
+
+ https://github.com/ethereum/go-ethereum/wiki/Building-Ethereum
 
 ### Building
 ```bash

--- a/registry/identity_registration_data.go
+++ b/registry/identity_registration_data.go
@@ -1,9 +1,8 @@
 package registry
 
 import (
-	"fmt"
-
 	"crypto/ecdsa"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/mysteriumnetwork/payments/identity"


### PR DESCRIPTION
Currently we only have OS X installation documentation in the README. Solidity maintains their own installation docs for various platforms as does Ethereum, we can use these.

Link to project docs for installation instructions.

Signed-off-by: Tobin C. Harding <me@tobin.cc>