### PR TITLE
Rename fee + Accountant ID in channel address generation

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -53,21 +53,22 @@ func deriveCreate2Address(salt string, msgSender string, implementation string) 
 
 	bytecode, _ := GetProxyCode(ensureNoPrefix(implementation))
 
-	input, _ := hex.DecodeString("ff" + ensureNoPrefix(msgSender) + salt + common.Bytes2Hex(crypto.Keccak256(bytecode)))
+	input, _ := hex.DecodeString("ff" + ensureNoPrefix(msgSender) + ensureNoPrefix(salt) + common.Bytes2Hex(crypto.Keccak256(bytecode)))
 	return "0x" + common.Bytes2Hex(crypto.Keccak256(input))[24:], nil
 }
 
 // GenerateChannelAddress generate channel address from given identity hash
-func GenerateChannelAddress(identity string, registry string, channelImplementation string) (address string, err error) {
+func GenerateChannelAddress(identity, accountant, registry, channelImplementation string) (address string, err error) {
 	if !isHexAddress(identity) || !isHexAddress(registry) || !isHexAddress(channelImplementation) {
 		return "", errors.New("Given identity, registry and channelImplementation params have to be hex addresses")
 	}
 
-	salt, err := toBytes32(identity)
+	saltBytes, err := hex.DecodeString(ensureNoPrefix(identity) + ensureNoPrefix(accountant))
 	if err != nil {
 		return "", err
 	}
 
+	salt := hex.EncodeToString(crypto.Keccak256(saltBytes))
 	return deriveCreate2Address(salt, registry, channelImplementation)
 }
 

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -42,15 +42,16 @@ func TestDeriveCreate2Address(t *testing.T) {
 func TestGenerateChannelAddress(t *testing.T) {
 	identity := "0x265B4A774A5CE7A975CA8401A43440EFEE58EB15"
 	registry := "0x6bb8345c9d996be4fab652f4a15813303d630b66"
+	accountantAddress := "0x676b9a084aC11CEeF680AF6FFbE99b24106F47e7"
 	channelImplementation := "0x99a73d53959a8fcbe6e67631d39de3cffd3ac9a2"
-	expectedChannelAddress := "0x777516c36ceef01ff12f954f7b4a0ea4be4abc0a"
+	expectedChannelAddress := "0x75bc5ea5f48949032278179132d367f06ab7570e"
 
-	_, err := GenerateChannelAddress("", "", "")
+	_, err := GenerateChannelAddress("", "", "", "")
 	assert.EqualError(t, err, "Given identity, registry and channelImplementation params have to be hex addresses")
 
-	channelAddress, err := GenerateChannelAddress(identity, registry, channelImplementation)
-	assert.Equal(t, expectedChannelAddress, channelAddress)
+	channelAddress, err := GenerateChannelAddress(identity, accountantAddress, registry, channelImplementation)
 	assert.Nil(t, err)
+	assert.Equal(t, expectedChannelAddress, channelAddress)
 }
 
 func TestGenerateProviderChannelID(t *testing.T) {

--- a/crypto/invoice.go
+++ b/crypto/invoice.go
@@ -28,13 +28,13 @@ import (
 type Invoice struct {
 	AgreementID    uint64
 	AgreementTotal uint64
-	Fee            uint64
+	TransactorFee  uint64
 	Hashlock       string
 	Provider       string
 }
 
 // CreateInvoice creates new invoice
-func CreateInvoice(agreementID, agreementTotal, fee uint64, r []byte) Invoice {
+func CreateInvoice(agreementID, agreementTotal, transactorFee uint64, r []byte) Invoice {
 	if r == nil {
 		r = make([]byte, 32)
 		rand.Read(r)
@@ -43,7 +43,7 @@ func CreateInvoice(agreementID, agreementTotal, fee uint64, r []byte) Invoice {
 	return Invoice{
 		AgreementID:    agreementID,
 		AgreementTotal: agreementTotal,
-		Fee:            fee,
+		TransactorFee:  transactorFee,
 		Hashlock:       hex.EncodeToString(crypto.Keccak256(r)),
 	}
 }

--- a/crypto/message.go
+++ b/crypto/message.go
@@ -40,7 +40,7 @@ type ExchangeMessage struct {
 
 // CreateExchangeMessage creates new exchange message with it's promise
 func CreateExchangeMessage(invoice Invoice, promiseAmount uint64, channelID string, ks *keystore.KeyStore, signer common.Address) (*ExchangeMessage, error) {
-	promise, err := CreatePromise(channelID, promiseAmount, invoice.Fee, invoice.Hashlock, ks, signer)
+	promise, err := CreatePromise(channelID, promiseAmount, invoice.TransactorFee, invoice.Hashlock, ks, signer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1) Renamed fee to transactor fee in invoice.
2) Accountant ID added to consumer channel address generation.
