### PR TITLE
forced dry runs for transactions with gas limits

### DIFF
--- a/client/retryable_client.go
+++ b/client/retryable_client.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/mysteriumnetwork/payments/bindings"
@@ -37,6 +38,7 @@ type blockchain interface {
 	SubscribeToChannelOpenedEvents(accountantAddress common.Address) (sink chan *bindings.AccountantImplementationChannelOpened, cancel func(), err error)
 	SubscribeToPromiseSettledEventByChannelID(accountantID common.Address, providerAddresses [][32]byte) (sink chan *bindings.AccountantImplementationPromiseSettled, cancel func(), err error)
 	NetworkID() (*big.Int, error)
+	EstimateGas(msg ethereum.CallMsg) (uint64, error)
 }
 
 // BlockchainWithRetries takes in the plain blockchain implementation and exposes methods that will retry the underlying bc methods before giving up.
@@ -426,6 +428,11 @@ func (bwr *BlockchainWithRetries) NetworkID() (*big.Int, error) {
 		return nil
 	})
 	return res, err
+}
+
+// EstimateGas proxies the estimate gas call to the underlying blockchain since no network calls are performed.
+func (bwr *BlockchainWithRetries) EstimateGas(msg ethereum.CallMsg) (uint64, error) {
+	return bwr.bc.EstimateGas(msg)
 }
 
 // Stop stops the blockhain with retries aborting any waits for retries

--- a/client/with_dry_runs.go
+++ b/client/with_dry_runs.go
@@ -1,0 +1,236 @@
+package client
+
+import (
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/mysteriumnetwork/payments/bindings"
+	"github.com/pkg/errors"
+)
+
+// WithDryRuns forces a dry run before running a write transaction on blockchain.
+// Ethereum client will perform a dry run on a transaction with no gas limit set.
+// This component will perform a dry run if and only if the gas limit is set to a non zero value.
+// In this way, the dry run is always performed before sending the transaction to the network.
+// For convenience, this component proxies read only calls to the underlying blockchain.
+type WithDryRuns struct {
+	bc blockchain
+}
+
+// NewWithDryRuns creates a new instance of client with dry runs.
+func NewWithDryRuns(bc blockchain) *WithDryRuns {
+	return &WithDryRuns{
+		bc: bc,
+	}
+}
+
+type gasLimitProvider interface {
+	GetGasLimit() uint64
+}
+
+// The params for the dry run should be in the strict order as required by the smart contract.
+func (cwdr *WithDryRuns) dryRun(glp gasLimitProvider, binding string, from, to common.Address, method string, params ...interface{}) (uint64, error) {
+	// If the gas limit is set to 0, ethereum client will do the estimation for us.
+	// We only force the estimation if the gas limit is set to a non zero value.
+	if glp.GetGasLimit() == 0 {
+		return 0, nil
+	}
+	parsed, err := abi.JSON(strings.NewReader(binding))
+	if err != nil {
+		return 0, errors.Wrap(err, "could not deserialize ABI")
+	}
+	input, err := parsed.Pack(method, params...)
+	if err != nil {
+		return 0, errors.Wrap(err, "could not pack input")
+	}
+	msg := ethereum.CallMsg{From: from, To: &to, Data: input}
+	gas, err := cwdr.bc.EstimateGas(msg)
+	return gas, errors.Wrap(err, "could not estimate gas")
+}
+
+// TransferMyst transfers myst
+func (cwdr *WithDryRuns) TransferMyst(req TransferRequest) (tx *types.Transaction, err error) {
+	_, err = cwdr.dryRun(
+		req,
+		bindings.MystTokenABI,
+		req.Identity,
+		req.MystAddress,
+		"transfer",
+		req.Recipient,
+		req.Amount,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "transaction dry run failed")
+	}
+
+	return cwdr.bc.TransferMyst(req)
+}
+
+// SettlePromise is settling the given consumer issued promise
+func (cwdr *WithDryRuns) SettlePromise(req SettleRequest) (*types.Transaction, error) {
+	lock := [32]byte{}
+	copy(lock[:], req.Promise.R)
+
+	_, err := cwdr.dryRun(
+		req,
+		bindings.ChannelImplementationABI,
+		req.Identity,
+		req.ChannelID,
+		"settlePromise",
+		big.NewInt(0).SetUint64(req.Promise.Amount),
+		big.NewInt(0).SetUint64(req.Promise.Fee),
+		lock,
+		req.Promise.Signature,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "transaction dry run failed")
+	}
+
+	return cwdr.SettlePromise(req)
+}
+
+// RegisterIdentity registers the given identity on blockchain
+func (cwdr *WithDryRuns) RegisterIdentity(rr RegistrationRequest) (*types.Transaction, error) {
+	_, err := cwdr.dryRun(
+		rr,
+		bindings.RegistryABI,
+		rr.Identity,
+		rr.RegistryAddress,
+		"registerIdentity",
+		rr.AccountantID,
+		rr.Loan,
+		rr.TransactorFee,
+		rr.Beneficiary,
+		rr.Signature,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "transaction dry run failed")
+	}
+
+	return cwdr.bc.RegisterIdentity(rr)
+}
+
+// SettleAndRebalance is settling given accountant issued promise
+func (cwdr *WithDryRuns) SettleAndRebalance(req SettleAndRebalanceRequest) (*types.Transaction, error) {
+	_, err := cwdr.dryRun(
+		req,
+		bindings.AccountantImplementationABI,
+		req.Identity,
+		req.AccountantID,
+		"settleAndRebalance",
+		toBytes32(req.Promise.ChannelID),
+		big.NewInt(0).SetUint64(req.Promise.Amount),
+		big.NewInt(0).SetUint64(req.Promise.Fee),
+		toBytes32(req.Promise.R),
+		req.Promise.Signature,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "transaction dry run failed")
+	}
+	return cwdr.bc.SettleAndRebalance(req)
+}
+
+// GetAccountantFee fetches the accountant fee from blockchain
+func (cwdr *WithDryRuns) GetAccountantFee(accountantAddress common.Address) (uint16, error) {
+	return cwdr.bc.GetAccountantFee(accountantAddress)
+}
+
+// CalculateAccountantFee fetches the accountant fee from blockchain
+func (cwdr *WithDryRuns) CalculateAccountantFee(accountantAddress common.Address, value uint64) (*big.Int, error) {
+	return cwdr.bc.CalculateAccountantFee(accountantAddress, value)
+}
+
+// IsRegisteredAsProvider checks if the provider is registered with the accountant properly
+func (cwdr *WithDryRuns) IsRegisteredAsProvider(accountantAddress, registryAddress, addressToCheck common.Address) (bool, error) {
+	return cwdr.bc.IsRegisteredAsProvider(accountantAddress, registryAddress, addressToCheck)
+}
+
+// GetProviderChannel returns the provider channel
+func (cwdr *WithDryRuns) GetProviderChannel(accountantAddress common.Address, addressToCheck common.Address) (ProviderChannel, error) {
+	return cwdr.bc.GetProviderChannel(accountantAddress, addressToCheck)
+}
+
+// IsRegistered checks wether the given identity is registered or not
+func (cwdr *WithDryRuns) IsRegistered(registryAddress, addressToCheck common.Address) (bool, error) {
+	return cwdr.bc.IsRegistered(registryAddress, addressToCheck)
+}
+
+// SubscribeToPromiseSettledEvent subscribes to promise settled events
+func (cwdr *WithDryRuns) SubscribeToPromiseSettledEvent(providerID, accountantID common.Address) (sink chan *bindings.AccountantImplementationPromiseSettled, cancel func(), err error) {
+	return cwdr.bc.SubscribeToPromiseSettledEvent(providerID, accountantID)
+}
+
+// GetMystBalance returns the balance in myst
+func (cwdr *WithDryRuns) GetMystBalance(mystSCAddress, address common.Address) (*big.Int, error) {
+	return cwdr.bc.GetMystBalance(mystSCAddress, address)
+}
+
+// SubscribeToConsumerBalanceEvent subscribes to the consumer balance change events
+func (cwdr *WithDryRuns) SubscribeToConsumerBalanceEvent(channel, mystSCAddress common.Address, timeout time.Duration) (chan *bindings.MystTokenTransfer, func(), error) {
+	return cwdr.bc.SubscribeToConsumerBalanceEvent(channel, mystSCAddress, timeout)
+}
+
+// GetRegistrationFee returns the registration fee
+func (cwdr *WithDryRuns) GetRegistrationFee(registryAddress common.Address) (*big.Int, error) {
+	return cwdr.bc.GetRegistrationFee(registryAddress)
+}
+
+// IsAccountantRegistered checks if given accountant is registered and returns true or false.
+func (cwdr *WithDryRuns) IsAccountantRegistered(registryAddress, acccountantID common.Address) (bool, error) {
+	return cwdr.bc.IsAccountantRegistered(registryAddress, acccountantID)
+}
+
+// GetAccountantOperator returns operator address of given accountant
+func (cwdr *WithDryRuns) GetAccountantOperator(accountantID common.Address) (common.Address, error) {
+	return cwdr.bc.GetAccountantOperator(accountantID)
+}
+
+// GetConsumerChannelsAccountant returns the consumer channels accountant
+func (cwdr *WithDryRuns) GetConsumerChannelsAccountant(channelAddress common.Address) (ConsumersAccountant, error) {
+	return cwdr.bc.GetConsumerChannelsAccountant(channelAddress)
+}
+
+// GetConsumerChannelOperator returns the consumer channel operator/identity
+func (cwdr *WithDryRuns) GetConsumerChannelOperator(channelAddress common.Address) (common.Address, error) {
+	return cwdr.bc.GetConsumerChannelOperator(channelAddress)
+}
+
+// GetProviderChannelByID returns the given channel information
+func (cwdr *WithDryRuns) GetProviderChannelByID(acc common.Address, chID []byte) (ProviderChannel, error) {
+	return cwdr.bc.GetProviderChannelByID(acc, chID)
+}
+
+// SubscribeToIdentityRegistrationEvents subscribes to identity registration events
+func (cwdr *WithDryRuns) SubscribeToIdentityRegistrationEvents(registryAddress common.Address, accountantIDs []common.Address) (sink chan *bindings.RegistryRegisteredIdentity, cancel func(), err error) {
+	return cwdr.bc.SubscribeToIdentityRegistrationEvents(registryAddress, accountantIDs)
+}
+
+// SubscribeToConsumerChannelBalanceUpdate subscribes to consumer channel balance update events
+func (cwdr *WithDryRuns) SubscribeToConsumerChannelBalanceUpdate(mystSCAddress common.Address, channelAddresses []common.Address) (sink chan *bindings.MystTokenTransfer, cancel func(), err error) {
+	return cwdr.bc.SubscribeToConsumerChannelBalanceUpdate(mystSCAddress, channelAddresses)
+}
+
+// SubscribeToProviderChannelBalanceUpdate subscribes to provider channel balance update events
+func (cwdr *WithDryRuns) SubscribeToProviderChannelBalanceUpdate(accountantAddress common.Address, channelAddresses [][32]byte) (sink chan *bindings.AccountantImplementationChannelBalanceUpdated, cancel func(), err error) {
+	return cwdr.bc.SubscribeToProviderChannelBalanceUpdate(accountantAddress, channelAddresses)
+}
+
+// SubscribeToChannelOpenedEvents subscribes to provider channel opened events
+func (cwdr *WithDryRuns) SubscribeToChannelOpenedEvents(accountantAddress common.Address) (sink chan *bindings.AccountantImplementationChannelOpened, cancel func(), err error) {
+	return cwdr.bc.SubscribeToChannelOpenedEvents(accountantAddress)
+}
+
+// SubscribeToPromiseSettledEventByChannelID subscribes to promise settled events
+func (cwdr *WithDryRuns) SubscribeToPromiseSettledEventByChannelID(accountantID common.Address, providerAddresses [][32]byte) (sink chan *bindings.AccountantImplementationPromiseSettled, cancel func(), err error) {
+	return cwdr.bc.SubscribeToPromiseSettledEventByChannelID(accountantID, providerAddresses)
+}
+
+// NetworkID returns the network id
+func (cwdr *WithDryRuns) NetworkID() (*big.Int, error) {
+	return cwdr.bc.NetworkID()
+}


### PR DESCRIPTION
Setting gas limits will make ethereum client skip dry runs. Added a client wrapper that forces such requests to perform a dry run before going to the network.

updates https://github.com/mysteriumnetwork/transactor/issues/21