### PR TITLE
Use proper hash in gas incrementor

### DIFF
--- a/fees/incrementor_test.go
+++ b/fees/incrementor_test.go
@@ -59,7 +59,7 @@ func TestGasPriceIncrementor(t *testing.T) {
 		assert.True(t, c.sent, "should be sent")
 		assert.True(t, c.checked, "should be checked")
 		assert.True(t, sg.signed, "should be signed")
-		altered, err := st.tx.getOriginal()
+		altered, err := st.tx.getLatestTx()
 		assert.NoError(t, err)
 
 		assert.Equal(t,
@@ -101,7 +101,7 @@ func TestGasPriceIncrementor(t *testing.T) {
 			[]TransactionState{TxStateCreated, TxStateSucceed},
 
 			st.stateHistory)
-		altered, err := st.tx.getOriginal()
+		altered, err := st.tx.getLatestTx()
 		assert.NoError(t, err)
 		assert.Equal(t, chid, st.tx.ChainID)
 		assert.Equal(t, originalGasPrice, altered.GasPrice(), "original gas price should stay the same")
@@ -139,7 +139,7 @@ func TestGasPriceIncrementor(t *testing.T) {
 
 			st.stateHistory)
 
-		altered, err := st.tx.getOriginal()
+		altered, err := st.tx.getLatestTx()
 		assert.Equal(t, chid, st.tx.ChainID)
 		assert.NoError(t, err)
 		assert.Equal(t, new(big.Int).SetInt64(4), altered.GasPrice(), "gas price should be increased once")

--- a/fees/transaction.go
+++ b/fees/transaction.go
@@ -44,13 +44,13 @@ const (
 
 // Transaction objects is used when handling transactions.
 type Transaction struct {
-	// UniqueID is a combination of Tx hash and chainID.
-	UniqueID   string
-	Opts       TransactionOpts
-	State      TransactionState
-	TxHashHex  string
-	ChainID    int64
-	OriginalTx []byte
+	// UniqueID is a combination of the original tx hash and chainID.
+	UniqueID       string
+	Opts           TransactionOpts
+	State          TransactionState
+	OrignalHashHex string
+	ChainID        int64
+	LatestTx       []byte
 }
 
 // TransactionOpts are provided when creating a new transaction.
@@ -69,8 +69,8 @@ type TransactionOpts struct {
 }
 
 // TransactionUniqueID returns a unique ID for a transaction.
-func TransactionUniqueID(txHashHex string, chainID int64) string {
-	return fmt.Sprintf("%s|%d", txHashHex, chainID)
+func TransactionUniqueID(orignalHash string, chainID int64) string {
+	return fmt.Sprintf("%s|%d", orignalHash, chainID)
 }
 
 func (t *TransactionOpts) validate() error {
@@ -105,12 +105,12 @@ func newTransaction(tx *types.Transaction, chainID int64, opts TransactionOpts) 
 	}
 
 	return &Transaction{
-		UniqueID:   TransactionUniqueID(hash, chainID),
-		Opts:       opts,
-		State:      TxStateCreated,
-		TxHashHex:  hash,
-		ChainID:    chainID,
-		OriginalTx: marshaled,
+		UniqueID:       TransactionUniqueID(hash, chainID),
+		Opts:           opts,
+		State:          TxStateCreated,
+		OrignalHashHex: hash,
+		ChainID:        chainID,
+		LatestTx:       marshaled,
 	}, nil
 }
 
@@ -122,9 +122,9 @@ func (t *Transaction) isExpired() bool {
 	return time.Now().After(*t.Opts.ValidUntil)
 }
 
-func (t *Transaction) getOriginal() (*types.Transaction, error) {
+func (t *Transaction) getLatestTx() (*types.Transaction, error) {
 	tx := &types.Transaction{}
-	return tx, tx.UnmarshalJSON(t.OriginalTx)
+	return tx, tx.UnmarshalJSON(t.LatestTx)
 }
 
 func (t *Transaction) rebuiledWithNewGasPrice(tx *types.Transaction, newGasPrice *big.Int) *types.Transaction {


### PR DESCRIPTION
This fixes a problem where we would use the old hash after incrementing price once.

Closes: https://github.com/mysteriumnetwork/transactor/issues/208