### PR TITLE
Add interface methods for custody transfers

### DIFF
--- a/client/bc.go
+++ b/client/bc.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/mysteriumnetwork/payments/bindings"
+)
+
+type BC interface {
+	CalculateHermesFee(hermesAddress common.Address, value *big.Int) (*big.Int, error)
+	IsHermesActive(hermesID common.Address) (bool, error)
+	IsHermesRegistered(registryAddress, acccountantID common.Address) (bool, error)
+
+	GetHermesFee(hermesAddress common.Address) (uint16, error)
+	GetHermessAvailableBalance(hermesAddress common.Address) (*big.Int, error)
+	GetHermesURL(registryID, hermesID common.Address) (string, error)
+	GetHermes(registryID, hermesID common.Address) (Hermes, error)
+	GetHermesOperator(hermesID common.Address) (common.Address, error)
+	GetProviderChannel(hermesAddress common.Address, addressToCheck common.Address, pending bool) (ProviderChannel, error)
+	GetMystBalance(mystSCAddress, address common.Address) (*big.Int, error)
+	GetConsumerChannelsHermes(channelAddress common.Address) (ConsumersHermes, error)
+	GetConsumerChannelOperator(channelAddress common.Address) (common.Address, error)
+	GetProviderChannelByID(acc common.Address, chID []byte) (ProviderChannel, error)
+	GetConsumerChannel(addr common.Address, mystSCAddress common.Address) (ConsumerChannel, error)
+	GetEthBalance(address common.Address) (*big.Int, error)
+	GetStakeThresholds(hermesID common.Address) (min, max *big.Int, err error)
+	GetBeneficiary(registryAddress, identity common.Address) (common.Address, error)
+	GetLastRegistryNonce(registry common.Address) (*big.Int, error)
+	GetChannelImplementationByVersion(registryID common.Address, version *big.Int) (common.Address, error)
+
+	IsRegisteredAsProvider(hermesAddress, registryAddress, addressToCheck common.Address) (bool, error)
+	IsRegistered(registryAddress, addressToCheck common.Address) (bool, error)
+	RegisterIdentity(rr RegistrationRequest) (*types.Transaction, error)
+	IncreaseProviderStake(req ProviderStakeIncreaseRequest) (*types.Transaction, error)
+
+	SettleAndRebalance(req SettleAndRebalanceRequest) (*types.Transaction, error)
+	SettleWithBeneficiary(req SettleWithBeneficiaryRequest) (*types.Transaction, error)
+	SettlePromise(req SettleRequest) (*types.Transaction, error)
+	DecreaseProviderStake(req DecreaseProviderStakeRequest) (*types.Transaction, error)
+	SettleIntoStake(req SettleIntoStakeRequest) (*types.Transaction, error)
+
+	SubscribeToPromiseSettledEvent(providerID, hermesID common.Address) (sink chan *bindings.HermesImplementationPromiseSettled, cancel func(), err error)
+	SubscribeToConsumerBalanceEvent(channel, mystSCAddress common.Address, timeout time.Duration) (chan *bindings.MystTokenTransfer, func(), error)
+	SubscribeToIdentityRegistrationEvents(registryAddress common.Address) (sink chan *bindings.RegistryRegisteredIdentity, cancel func(), err error)
+	SubscribeToConsumerChannelBalanceUpdate(mystSCAddress common.Address, channelAddresses []common.Address) (sink chan *bindings.MystTokenTransfer, cancel func(), err error)
+	SubscribeToPromiseSettledEventByChannelID(hermesID common.Address, providerAddresses [][32]byte) (sink chan *bindings.HermesImplementationPromiseSettled, cancel func(), err error)
+	SubscribeToMystTokenTransfers(mystSCAddress common.Address) (chan *bindings.MystTokenTransfer, func(), error)
+	FilterLogs(q ethereum.FilterQuery) ([]types.Log, error)
+
+	NetworkID() (*big.Int, error)
+	SuggestGasPrice() (*big.Int, error)
+	HeaderByNumber(number *big.Int) (*types.Header, error)
+
+	TransferMyst(req TransferRequest) (tx *types.Transaction, err error)
+	TransferEth(etr EthTransferRequest) (*types.Transaction, error)
+
+	SendTransaction(tx *types.Transaction) error
+	TransactionReceipt(hash common.Hash) (*types.Receipt, error)
+	TransactionByHash(hash common.Hash) (*types.Transaction, bool, error)
+
+	RewarderTotalPayoutsFor(rewarderAddress common.Address, payoutsFor common.Address) (*big.Int, error)
+	RewarderAirDrop(req RewarderAirDrop) (*types.Transaction, error)
+	RewarderUpdateRoot(req RewarderUpdateRoot) (*types.Transaction, error)
+	RewarderTotalClaimed(rewarderAddress common.Address) (*big.Int, error)
+	CustodyTransferTokens(req CustodyTokensTransfer) (*types.Transaction, error)
+}

--- a/client/multichain_client.go
+++ b/client/multichain_client.go
@@ -461,3 +461,11 @@ func (mbc *MultichainBlockchainClient) RewarderTotalClaimed(chainID int64, rewar
 	}
 	return bc.RewarderTotalClaimed(rewarderAddress)
 }
+
+func (mbc *MultichainBlockchainClient) CustodyTransferTokens(chainID int64, req CustodyTokensTransfer) (*types.Transaction, error) {
+	bc, err := mbc.getClientByChain(chainID)
+	if err != nil {
+		return nil, err
+	}
+	return bc.CustodyTransferTokens(req)
+}

--- a/client/retryable_client.go
+++ b/client/retryable_client.go
@@ -29,56 +29,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-type BC interface {
-	GetHermesFee(hermesAddress common.Address) (uint16, error)
-	CalculateHermesFee(hermesAddress common.Address, value *big.Int) (*big.Int, error)
-	IsRegisteredAsProvider(hermesAddress, registryAddress, addressToCheck common.Address) (bool, error)
-	GetProviderChannel(hermesAddress common.Address, addressToCheck common.Address, pending bool) (ProviderChannel, error)
-	IsRegistered(registryAddress, addressToCheck common.Address) (bool, error)
-	SubscribeToPromiseSettledEvent(providerID, hermesID common.Address) (sink chan *bindings.HermesImplementationPromiseSettled, cancel func(), err error)
-	GetMystBalance(mystSCAddress, address common.Address) (*big.Int, error)
-	SubscribeToConsumerBalanceEvent(channel, mystSCAddress common.Address, timeout time.Duration) (chan *bindings.MystTokenTransfer, func(), error)
-	RegisterIdentity(rr RegistrationRequest) (*types.Transaction, error)
-	TransferMyst(req TransferRequest) (tx *types.Transaction, err error)
-	IsHermesRegistered(registryAddress, acccountantID common.Address) (bool, error)
-	GetHermesOperator(hermesID common.Address) (common.Address, error)
-	SettleAndRebalance(req SettleAndRebalanceRequest) (*types.Transaction, error)
-	SettleWithBeneficiary(req SettleWithBeneficiaryRequest) (*types.Transaction, error)
-	GetConsumerChannelsHermes(channelAddress common.Address) (ConsumersHermes, error)
-	GetConsumerChannelOperator(channelAddress common.Address) (common.Address, error)
-	GetProviderChannelByID(acc common.Address, chID []byte) (ProviderChannel, error)
-	SubscribeToIdentityRegistrationEvents(registryAddress common.Address) (sink chan *bindings.RegistryRegisteredIdentity, cancel func(), err error)
-	SubscribeToConsumerChannelBalanceUpdate(mystSCAddress common.Address, channelAddresses []common.Address) (sink chan *bindings.MystTokenTransfer, cancel func(), err error)
-	SettlePromise(req SettleRequest) (*types.Transaction, error)
-	SubscribeToPromiseSettledEventByChannelID(hermesID common.Address, providerAddresses [][32]byte) (sink chan *bindings.HermesImplementationPromiseSettled, cancel func(), err error)
-	SubscribeToMystTokenTransfers(mystSCAddress common.Address) (chan *bindings.MystTokenTransfer, func(), error)
-	NetworkID() (*big.Int, error)
-	GetConsumerChannel(addr common.Address, mystSCAddress common.Address) (ConsumerChannel, error)
-	GetEthBalance(address common.Address) (*big.Int, error)
-	TransferEth(etr EthTransferRequest) (*types.Transaction, error)
-	GetHermessAvailableBalance(hermesAddress common.Address) (*big.Int, error)
-	DecreaseProviderStake(req DecreaseProviderStakeRequest) (*types.Transaction, error)
-	SettleIntoStake(req SettleIntoStakeRequest) (*types.Transaction, error)
-	IncreaseProviderStake(req ProviderStakeIncreaseRequest) (*types.Transaction, error)
-	TransactionReceipt(hash common.Hash) (*types.Receipt, error)
-	GetHermesURL(registryID, hermesID common.Address) (string, error)
-	GetStakeThresholds(hermesID common.Address) (min, max *big.Int, err error)
-	GetBeneficiary(registryAddress, identity common.Address) (common.Address, error)
-	SuggestGasPrice() (*big.Int, error)
-	FilterLogs(q ethereum.FilterQuery) ([]types.Log, error)
-	HeaderByNumber(number *big.Int) (*types.Header, error)
-	GetLastRegistryNonce(registry common.Address) (*big.Int, error)
-	SendTransaction(tx *types.Transaction) error
-	IsHermesActive(hermesID common.Address) (bool, error)
-	GetHermes(registryID, hermesID common.Address) (Hermes, error)
-	GetChannelImplementationByVersion(registryID common.Address, version *big.Int) (common.Address, error)
-	TransactionByHash(hash common.Hash) (*types.Transaction, bool, error)
-	RewarderTotalPayoutsFor(rewarderAddress common.Address, payoutsFor common.Address) (*big.Int, error)
-	RewarderAirDrop(req RewarderAirDrop) (*types.Transaction, error)
-	RewarderUpdateRoot(req RewarderUpdateRoot) (*types.Transaction, error)
-	RewarderTotalClaimed(rewarderAddress common.Address) (*big.Int, error)
-}
-
 // BlockchainWithRetries takes in the plain blockchain implementation and exposes methods that will retry the underlying bc methods before giving up.
 // This is required as the ethereum client will occasionally spit a TLS error if running for prolonged periods of time.
 type BlockchainWithRetries struct {
@@ -783,4 +733,17 @@ func (bwr *BlockchainWithRetries) RewarderTotalClaimed(chainID int64, rewarderAd
 		return nil
 	})
 	return total, err
+}
+
+func (bwr *BlockchainWithRetries) CustodyTransferTokens(req CustodyTokensTransfer) (*types.Transaction, error) {
+	var res *types.Transaction
+	err := bwr.callWithRetry(func() error {
+		t, err := bwr.bc.CustodyTransferTokens(req)
+		if err != nil {
+			return errors.Wrap(err, "could get total claimed")
+		}
+		res = t
+		return nil
+	})
+	return res, err
 }

--- a/client/with_dry_runs.go
+++ b/client/with_dry_runs.go
@@ -354,3 +354,7 @@ func (cwdr *WithDryRuns) RewarderUpdateRoot(req RewarderUpdateRoot) (*types.Tran
 func (cwdr *WithDryRuns) RewarderTotalClaimed(rewarderAddress common.Address) (*big.Int, error) {
 	return cwdr.bc.RewarderTotalClaimed(rewarderAddress)
 }
+
+func (cwdr *WithDryRuns) CustodyTransferTokens(req CustodyTokensTransfer) (*types.Transaction, error) {
+	return cwdr.bc.CustodyTransferTokens(req)
+}


### PR DESCRIPTION
* Added a method to make custody token transfers
* Moved the `BC` interface to another file as it's always annoying to look for it somewhere random.