### PR TITLE
No more races with client

### DIFF
--- a/client/ethclient.go
+++ b/client/ethclient.go
@@ -63,7 +63,7 @@ func (c *ReconnectableEthClient) Reconnect() error {
 	}
 
 	c.client.Close()
-	c.client = client
+	*c.client = *client
 
 	return nil
 }

--- a/client/ethclient_test.go
+++ b/client/ethclient_test.go
@@ -35,5 +35,6 @@ func TestReconnectableEthClientCreatesNewClient(t *testing.T) {
 	assert.Nil(t, err)
 
 	c3 := client.Client()
-	assert.NotEqual(t, c1, c3)
+	assert.Equal(t, c1, c3)
+	assert.Equal(t, c2, c3)
 }

--- a/client/retryable_client.go
+++ b/client/retryable_client.go
@@ -722,7 +722,7 @@ func (bwr *BlockchainWithRetries) RewarderUpdateRoot(req RewarderUpdateRoot) (*t
 }
 
 // RewarderTotalClaimed is a free lookup in the blockchain for the total amount of claimed tokens in the blockchain.
-func (bwr *BlockchainWithRetries) RewarderTotalClaimed(chainID int64, rewarderAddress common.Address) (*big.Int, error) {
+func (bwr *BlockchainWithRetries) RewarderTotalClaimed(rewarderAddress common.Address) (*big.Int, error) {
 	var total *big.Int
 	err := bwr.callWithRetry(func() error {
 		t, err := bwr.bc.RewarderTotalClaimed(rewarderAddress)


### PR DESCRIPTION
Take note that this is not 100% bullet proof.

To make it bulletproof I'd need to wrap the following interface:

```
type bcc interface {
   bind.ContractBackend
   ...
   // some extra eth.client methods we're using
}
```

I don't think it's worth doing atm as this fix should solve 99% of the cases we encounter.

