### PR TITLE
Incrementor remake

### DIFF
--- a/client/with_dry_runs.go
+++ b/client/with_dry_runs.go
@@ -379,6 +379,6 @@ func (cwdr *WithDryRuns) SubscribeToWithdrawalPromiseSettledEvent(providerID, he
 	return cwdr.bc.SubscribeToWithdrawalPromiseSettledEvent(providerID, hermesID)
 }
 
-func (cwdr *WithDryRuns) FilterPromiseSettledEventByChannelID(chainID int64, from uint64, to *uint64, hermesID common.Address, providerAddresses [][32]byte) ([]bindings.HermesImplementationPromiseSettled, error) {
+func (cwdr *WithDryRuns) FilterPromiseSettledEventByChannelID(from uint64, to *uint64, hermesID common.Address, providerAddresses [][32]byte) ([]bindings.HermesImplementationPromiseSettled, error) {
 	return cwdr.bc.FilterPromiseSettledEventByChannelID(from, to, hermesID, providerAddresses)
 }

--- a/transfer/incrementor.go
+++ b/transfer/incrementor.go
@@ -38,15 +38,16 @@ type GasPriceIncremenetor struct {
 	cfg     GasIncrementorConfig
 	signers safeSigners
 
-	syncer *syncer
-	logFn  LogFunc
-	stop   chan struct{}
-	once   sync.Once
+	logFn LogFunc
+	stop  chan struct{}
+	once  sync.Once
 }
 
 // GasIncrementorConfig is provided to the incrementor to configure it.
 type GasIncrementorConfig struct {
+	WorkerCount       int
 	PullInterval      time.Duration
+	PullEntryCount    int64
 	MaxQueuePerSigner int
 }
 
@@ -61,7 +62,7 @@ type Storage interface {
 	//
 	// Entries should be filtered by possible signers. If incrementor cannot sign the transaction
 	// it should not received it.
-	GetIncrementorTransactionsToCheck(possibleSigners []string) (tx []Transaction, err error)
+	GetIncrementorTransactionsToCheck(maxEntries int64, possibleSigners []string) (tx []Transaction, err error)
 
 	// GasIncrementorSenderQueue returns the length of a queue for a single sender.
 	GetIncrementorSenderQueue(sender string) (length int, err error)
@@ -79,6 +80,13 @@ type LogFunc func(Transaction, error)
 
 // NewGasPriceIncremenetor returns a new incrementer instance.
 func NewGasPriceIncremenetor(cfg GasIncrementorConfig, storage Storage, cl MultichainClient, signers Signers) *GasPriceIncremenetor {
+	if cfg.WorkerCount <= 0 {
+		cfg.WorkerCount = 1
+	}
+	if cfg.PullEntryCount <= 0 {
+		cfg.PullEntryCount = 1
+	}
+
 	return &GasPriceIncremenetor{
 		storage: storage,
 		bc:      cl,
@@ -88,8 +96,7 @@ func NewGasPriceIncremenetor(cfg GasIncrementorConfig, storage Storage, cl Multi
 			signers: signers,
 		},
 
-		syncer: newSyncer(),
-		stop:   make(chan struct{}, 0),
+		stop: make(chan struct{}, 0),
 	}
 }
 
@@ -98,28 +105,79 @@ func NewGasPriceIncremenetor(cfg GasIncrementorConfig, storage Storage, cl Multi
 // It will query the given storage for any entries that it needs to check
 // for gas increase, trying to check their status.
 func (i *GasPriceIncremenetor) Run() {
-	process := func(txs []Transaction) {
-		for _, tx := range txs {
-			switch tx.State {
-			case TxStateFailed, TxStateSucceed:
-				// Force skip transactions that are finalized.
-			default:
-				i.tryWatch(tx)
-			}
-		}
-	}
-
 	for {
 		select {
 		case <-i.stop:
 			return
 
 		case <-time.After(i.cfg.PullInterval):
-			txs, err := i.storage.GetIncrementorTransactionsToCheck(i.signers.getSigners())
+			txs, err := i.storage.GetIncrementorTransactionsToCheck(i.cfg.PullEntryCount, i.signers.getSigners())
 			if err != nil {
 				continue
 			}
-			process(txs)
+
+			i.queueWork(txs)
+		}
+	}
+}
+
+func (i *GasPriceIncremenetor) watchOrIncrease(work chan Transaction) {
+	for tx := range work {
+		now := time.Now().UTC()
+
+		if tx.isExpired() {
+			i.transactionExpired(tx)
+			continue
+		}
+
+		ok, err := i.checkIfSuccess(tx)
+		if err != nil {
+			i.log(tx, fmt.Errorf("status check failed: %w", err))
+			if !errors.Is(err, ethereum.NotFound) {
+				continue
+			}
+		}
+
+		// If transaction was not a success and a certain amount of time
+		// has passed since last increase - increase gas price again.
+		if !ok && now.After(tx.NextIncreaseAfterUTC) {
+			if err := i.increaseGasPrice(tx); err != nil {
+				if i.isBlockchainErrorUnhandleable(err) {
+					i.log(tx, fmt.Errorf("received unhandleable increase error, marking tx as failed: %w", err))
+					i.transactionFailed(tx)
+					continue
+				}
+
+				i.log(tx, fmt.Errorf("gas price increase failed: %w", err))
+			}
+		}
+	}
+}
+
+func (i *GasPriceIncremenetor) queueWork(txs []Transaction) {
+	work := make(chan Transaction)
+
+	var wg sync.WaitGroup
+	for in := 0; in < i.cfg.WorkerCount; in++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			i.watchOrIncrease(work)
+		}()
+	}
+
+	// Close and wait on func exit
+	defer func() {
+		close(work)
+		wg.Wait()
+	}()
+
+	for _, o := range txs {
+		select {
+		case <-i.stop:
+			return
+		default:
+			work <- o
 		}
 	}
 }
@@ -171,78 +229,45 @@ func (i *GasPriceIncremenetor) CanQueue(sender common.Address) (bool, error) {
 	return length < i.cfg.MaxQueuePerSigner, nil
 }
 
-// tryWatch will try to watch a transaction.
-// If a transaction is already being watched, it will get skipped.
-func (i *GasPriceIncremenetor) tryWatch(tx Transaction) {
-	if i.syncer.txBeingWatched(tx) {
-		// Already watching
-		return
-	}
-	if err := tx.Opts.validate(); err != nil {
-		i.log(tx, fmt.Errorf("can't increment gas price, got wrong tx opts: %w", err))
-		return
+func (i *GasPriceIncremenetor) checkIfSuccess(tx Transaction) (bool, error) {
+	status, err := i.getTxStatus(tx)
+	if err != nil {
+		return false, err
 	}
 
-	i.syncer.txMarkBeingWatched(tx)
-	go func() {
-		defer i.syncer.txRemoveWatched(tx)
-		if err := i.watchAndIncrement(tx); err != nil {
-			i.log(tx, err)
-
-			if !tx.isExpired() {
-				return
-			}
-
-			if err := i.transactionFailed(tx); err != nil {
-				i.log(tx, err)
-			}
-		}
-
-	}()
+	switch status {
+	case StatusSucceeded:
+		return true, i.transactionSuccess(tx)
+	default:
+		return false, i.transactionSetNextCheck(tx)
+	}
 }
 
-func (i *GasPriceIncremenetor) watchAndIncrement(tx Transaction) error {
-	timeout := time.After(tx.Opts.Timeout)
-	incTimer := time.NewTicker(tx.Opts.IncreaseInterval)
-	defer incTimer.Stop()
-
-	checkTimer := time.NewTicker(tx.Opts.CheckInterval)
-	defer checkTimer.Stop()
-
-	for {
-		select {
-		case <-i.stop:
-			return nil
-		case <-checkTimer.C:
-			status, err := i.getTxStatus(tx)
-			if err != nil {
-				if !i.isBlockchainErrorUnhandleable(err) {
-					return err
-				}
-				i.log(tx, fmt.Errorf("received unhandleable receipt error, marking tx as failed: %w", err))
-				return i.transactionFailed(tx)
-			}
-			if status == StatusSucceeded {
-				return i.transactionSuccess(tx)
-			}
-		case <-incTimer.C:
-			newTx, err := i.increaseGasPrice(tx)
-			if err != nil {
-				if !i.isBlockchainErrorUnhandleable(err) {
-					return err
-				}
-				i.log(tx, fmt.Errorf("received unhandleable increase error, marking tx as failed: %w", err))
-				return i.transactionFailed(tx)
-			}
-			tx = newTx
-		case <-timeout:
-			return i.transactionFailed(tx)
-		}
+func (i *GasPriceIncremenetor) increaseGasPrice(tx Transaction) error {
+	org, err := tx.getLatestTx()
+	if err != nil {
+		return err
 	}
+
+	newGasPrice, _ := new(big.Float).Mul(
+		big.NewFloat(tx.Opts.PriceMultiplier),
+		new(big.Float).SetInt(org.GasPrice()),
+	).Int(nil)
+
+	if newGasPrice.Cmp(tx.Opts.MaxPrice) > 0 {
+		return fmt.Errorf("transaction with uniqueID '%s' failed, gas price limit of %s reached on chain %d", tx.UniqueID, tx.Opts.MaxPrice.String(), tx.ChainID)
+	}
+
+	newTx, err := i.signAndSend(tx.rebuiledWithNewGasPrice(org, newGasPrice), tx.ChainID, tx.SenderAddressHex)
+	if err != nil {
+		return err
+	}
+
+	return i.transactionPriceIncreased(tx, newTx)
 }
 
 func (i *GasPriceIncremenetor) isBlockchainErrorUnhandleable(err error) bool {
-	if errors.Is(err, core.ErrNonceTooHigh) || errors.Is(err, core.ErrNonceTooLow) || errors.Is(err, ethereum.NotFound) {
+	if errors.Is(err, core.ErrNonceTooHigh) || errors.Is(err, core.ErrNonceTooLow) {
 		return true
 	}
 
@@ -258,33 +283,6 @@ func (i *GasPriceIncremenetor) isBlockchainErrorUnhandleable(err error) bool {
 	default:
 		return false
 	}
-}
-
-func (i *GasPriceIncremenetor) increaseGasPrice(tx Transaction) (Transaction, error) {
-	org, err := tx.getLatestTx()
-	if err != nil {
-		return Transaction{}, err
-	}
-
-	newGasPrice, _ := new(big.Float).Mul(
-		big.NewFloat(tx.Opts.PriceMultiplier),
-		new(big.Float).SetInt(org.GasPrice()),
-	).Int(nil)
-
-	if newGasPrice.Cmp(tx.Opts.MaxPrice) > 0 {
-		if err := i.transactionFailed(tx); err != nil {
-			return Transaction{}, err
-		}
-
-		return Transaction{}, fmt.Errorf("transaction with uniqueID '%s' failed, gas price limit of %s reached on chain %d", tx.UniqueID, tx.Opts.MaxPrice.String(), tx.ChainID)
-	}
-
-	newTx, err := i.signAndSend(tx.rebuiledWithNewGasPrice(org, newGasPrice), tx.ChainID, tx.SenderAddressHex)
-	if err != nil {
-		return Transaction{}, i.transactionFailed(tx)
-	}
-
-	return i.transactionPriceIncreased(tx, newTx)
 }
 
 // BCTxStatus represents the status of tx on blockchain.
@@ -358,12 +356,29 @@ func (i *GasPriceIncremenetor) signAndSend(tx *types.Transaction, chainID int64,
 	return signedTx, nil
 }
 
-func (i *GasPriceIncremenetor) transactionFailed(tx Transaction) error {
+func (i *GasPriceIncremenetor) transactionFailed(tx Transaction) {
 	tx.State = TxStateFailed
-	if err := i.storage.UpsertIncrementorTransaction(tx); err != nil {
-		return fmt.Errorf("failed marking transaction as failed: %w", err)
-	}
 
+	err := i.storage.UpsertIncrementorTransaction(tx)
+	if err != nil {
+		i.log(tx, fmt.Errorf("failed marking transaction as failed: %w", err))
+	}
+}
+
+func (i *GasPriceIncremenetor) transactionExpired(tx Transaction) {
+	tx.State = TxStateExpired
+
+	err := i.storage.UpsertIncrementorTransaction(tx)
+	if err != nil {
+		i.log(tx, fmt.Errorf("failed marking transaction as expired: %w", err))
+	}
+}
+
+func (i *GasPriceIncremenetor) transactionSetNextCheck(tx Transaction) error {
+	tx.NextCheckAfterUTC = time.Now().UTC().Add(tx.Opts.CheckInterval)
+	if err := i.storage.UpsertIncrementorTransaction(tx); err != nil {
+		return fmt.Errorf("failed marking transaction succeed: %w", err)
+	}
 	return nil
 }
 
@@ -375,55 +390,26 @@ func (i *GasPriceIncremenetor) transactionSuccess(tx Transaction) error {
 	return nil
 }
 
-func (i *GasPriceIncremenetor) transactionPriceIncreased(tx Transaction, newTx *types.Transaction) (Transaction, error) {
-	var err error
-	tx.State = TxStatePriceIncreased
-	tx.LatestTx, err = newTx.MarshalJSON()
+func (i *GasPriceIncremenetor) transactionPriceIncreased(tx Transaction, newTx *types.Transaction) error {
+	blob, err := newTx.MarshalJSON()
 	if err != nil {
-		return Transaction{}, fmt.Errorf("failed to marshal internal transaction object: %w", err)
+		return fmt.Errorf("failed to marshal internal transaction object: %w", err)
 	}
 
+	tx.State = TxStatePriceIncreased
+	tx.NextIncreaseAfterUTC = time.Now().UTC().Add(tx.Opts.IncreaseInterval)
+	tx.LatestTx = blob
 	if err := i.storage.UpsertIncrementorTransaction(tx); err != nil {
-		return Transaction{}, fmt.Errorf("failed to update transaction after price increase: %w", err)
+		return fmt.Errorf("failed to update transaction after price increase: %w", err)
 	}
 
-	return tx, nil
+	return nil
 }
 
 func (i *GasPriceIncremenetor) log(tx Transaction, err error) {
 	if i.logFn != nil {
 		i.logFn(tx, err)
 	}
-}
-
-// syncer is used to sync Incrementor so that
-// we dont start tracking the same transaction multiple times.
-type syncer struct {
-	txs map[string]struct{}
-	m   sync.Mutex
-}
-
-func newSyncer() *syncer {
-	return &syncer{txs: make(map[string]struct{})}
-}
-
-func (s *syncer) txMarkBeingWatched(tx Transaction) {
-	s.m.Lock()
-	defer s.m.Unlock()
-	s.txs[tx.UniqueID] = struct{}{}
-}
-
-func (s *syncer) txBeingWatched(tx Transaction) bool {
-	s.m.Lock()
-	defer s.m.Unlock()
-	_, ok := s.txs[tx.UniqueID]
-	return ok
-}
-
-func (s *syncer) txRemoveWatched(tx Transaction) {
-	s.m.Lock()
-	defer s.m.Unlock()
-	delete(s.txs, tx.UniqueID)
 }
 
 // SignatureFunc is used to sign transactions when resubmitting them.

--- a/transfer/incrementor.go
+++ b/transfer/incrementor.go
@@ -123,6 +123,13 @@ func (i *GasPriceIncremenetor) Run() {
 
 func (i *GasPriceIncremenetor) watchOrIncrease(work chan Transaction) {
 	for tx := range work {
+		// Force skip transactions that are done in case the provider doesn't.
+		switch tx.State {
+		case TxStateCreated, TxStatePriceIncreased:
+		default:
+			continue
+		}
+
 		now := time.Now().UTC()
 
 		if tx.isExpired() {

--- a/transfer/incrementor_test.go
+++ b/transfer/incrementor_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -34,7 +33,9 @@ import (
 func TestGasPriceIncrementor(t *testing.T) {
 	chid := int64(9223372036854775790)
 	cfg := GasIncrementorConfig{
-		PullInterval:      time.Millisecond,
+		WorkerCount:       2,
+		PullEntryCount:    100,
+		PullInterval:      time.Millisecond * 3,
 		MaxQueuePerSigner: 100,
 	}
 	t.Run("gas price is increased and tx is successfull", func(t *testing.T) {
@@ -50,9 +51,10 @@ func TestGasPriceIncrementor(t *testing.T) {
 			sender: sg.SignatureFunc,
 		})
 		go inc.Run()
-		inc.InsertInitial(org, opts, sender)
+		err := inc.InsertInitial(org, opts, sender)
+		assert.NoError(t, err)
 		assert.Eventually(t, func() bool {
-			txs, _ := st.GetIncrementorTransactionsToCheck([]string{sender.Hex()})
+			txs, _ := st.GetIncrementorTransactionsToCheck(10, []string{sender.Hex()})
 			if len(txs) == 0 {
 				return false
 			}
@@ -69,10 +71,14 @@ func TestGasPriceIncrementor(t *testing.T) {
 		altered, err := st.tx.getLatestTx()
 		assert.NoError(t, err)
 
-		assert.Equal(t,
-			[]TransactionState{TxStateCreated, TxStatePriceIncreased, TxStateSucceed},
-
-			st.stateHistory)
+		priceIncreased := 0
+		for _, s := range st.stateHistory {
+			if s == TxStatePriceIncreased {
+				priceIncreased++
+			}
+		}
+		assert.Equal(t, 1, priceIncreased)
+		assert.Equal(t, TxStateSucceed, st.stateHistory[len(st.stateHistory)-1])
 
 		assert.Equal(t, chid, st.tx.ChainID)
 		assert.Equal(t, big.NewInt(2), altered.GasPrice(), "gas price should increase")
@@ -92,7 +98,7 @@ func TestGasPriceIncrementor(t *testing.T) {
 		go inc.Run()
 		inc.InsertInitial(org, opts, sender)
 		assert.Eventually(t, func() bool {
-			txs, _ := st.GetIncrementorTransactionsToCheck([]string{sender.Hex()})
+			txs, _ := st.GetIncrementorTransactionsToCheck(10, []string{sender.Hex()})
 			if len(txs) == 0 {
 				return false
 			}
@@ -107,55 +113,19 @@ func TestGasPriceIncrementor(t *testing.T) {
 		assert.False(t, c.sent, "already mind, should not check")
 		assert.False(t, sg.signed, "tx should not be signed")
 		assert.True(t, c.checked, "should be checked")
-		assert.Equal(t,
-			[]TransactionState{TxStateCreated, TxStateSucceed},
+		priceIncreased := 0
+		for _, s := range st.stateHistory {
+			if s == TxStatePriceIncreased {
+				priceIncreased++
+			}
+		}
+		assert.Equal(t, 0, priceIncreased)
+		assert.Equal(t, TxStateSucceed, st.stateHistory[len(st.stateHistory)-1])
 
-			st.stateHistory)
 		altered, err := st.tx.getLatestTx()
 		assert.NoError(t, err)
 		assert.Equal(t, chid, st.tx.ChainID)
 		assert.Equal(t, originalGasPrice, altered.GasPrice(), "original gas price should stay the same")
-	})
-	t.Run("tx fails if gas price is too big", func(t *testing.T) {
-		originalGasPrice := big.NewInt(2)
-		org := types.NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), 1, originalGasPrice, []byte{})
-		opts := defaultOpts()
-		opts.MaxPrice = new(big.Int).SetInt64(5)
-
-		st := &mockStorage{}
-		c := newClient(new(big.Int).Add(opts.MaxPrice, big.NewInt(5)))
-
-		sender := common.HexToAddress("")
-		sg := signer{}
-		inc := NewGasPriceIncremenetor(cfg, st, c, map[common.Address]SignatureFunc{
-			sender: sg.SignatureFunc,
-		})
-		go inc.Run()
-		inc.InsertInitial(org, opts, sender)
-		assert.Eventually(t, func() bool {
-			txs, _ := st.GetIncrementorTransactionsToCheck([]string{sender.Hex()})
-			if len(txs) == 0 {
-				return false
-			}
-			tx := txs[0]
-
-			return TxStateFailed == tx.State
-		}, time.Second, time.Millisecond*10)
-
-		inc.Stop()
-		assert.True(t, st.inserted)
-		assert.True(t, st.pulled)
-		assert.True(t, c.sent, "should be sent once")
-		assert.True(t, sg.signed, "tx should be signed")
-		assert.Equal(t,
-			[]TransactionState{TxStateCreated, TxStatePriceIncreased, TxStateFailed},
-
-			st.stateHistory)
-
-		altered, err := st.tx.getLatestTx()
-		assert.Equal(t, chid, st.tx.ChainID)
-		assert.NoError(t, err)
-		assert.Equal(t, new(big.Int).SetInt64(4), altered.GasPrice(), "gas price should be increased once")
 	})
 	t.Run("invalid opts, not inserted", func(t *testing.T) {
 		org := types.NewTransaction(1, common.HexToAddress("0x1"), big.NewInt(1), 1, big.NewInt(1), []byte{})
@@ -172,23 +142,12 @@ func TestGasPriceIncrementor(t *testing.T) {
 	})
 }
 
-func Test_syncer(t *testing.T) {
-	s := newSyncer()
-
-	tx := Transaction{UniqueID: "0x0"}
-	s.txMarkBeingWatched(tx)
-	assert.True(t, s.txBeingWatched(tx), "transaction should be watched")
-	s.txRemoveWatched(tx)
-	assert.False(t, s.txBeingWatched(tx), "transaction should no longer be watched")
-}
-
 func defaultOpts() TransactionOpts {
 	return TransactionOpts{
 		PriceMultiplier:  2.0,
 		MaxPrice:         new(big.Int).SetInt64(100),
-		Timeout:          time.Minute,
-		IncreaseInterval: time.Millisecond * 60,
-		CheckInterval:    time.Millisecond * 40,
+		IncreaseInterval: time.Millisecond * 15,
+		CheckInterval:    time.Millisecond * 10,
 	}
 }
 
@@ -215,7 +174,7 @@ func (s *mockStorage) UpsertIncrementorTransaction(tx Transaction) error {
 	return nil
 }
 
-func (s *mockStorage) GetIncrementorTransactionsToCheck(signers []string) (tx []Transaction, err error) {
+func (s *mockStorage) GetIncrementorTransactionsToCheck(count int64, signers []string) (tx []Transaction, err error) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.pulled = true
@@ -282,13 +241,6 @@ func TestGasPriceIncremenetor_isBlockchainErrorUnhandleable(t *testing.T) {
 		args args
 		want bool
 	}{
-		{
-			name: "detects ethereum not found error",
-			args: args{
-				err: fmt.Errorf("tortilla %w", ethereum.NotFound),
-			},
-			want: true,
-		},
 		{
 			name: "detects core nonce too low error",
 			args: args{


### PR DESCRIPTION
* Remove the infinite goroutine spawning.
* Removed the syncer. Not needed anymore
* **Introduced new workflow:**
  * Pull transactions from DB by two TS fields:
    *  NextCheck + NextIncrease. Idea is to pull if either one is before time.Now.UTC().
  * Spawn X amount of works who all do the same
    * Always check if transaction was successful
    * If NextIncrease is before time.Now.UTC() increase gas price
    * **If check received `NotFound` still increase the gas price if time has passed.**
      * This is a bit controversial.

Closes: https://github.com/mysteriumnetwork/payments/issues/123