### PR TITLE
Handle too many requests

### DIFF
--- a/client/sort/default_funcs.go
+++ b/client/sort/default_funcs.go
@@ -82,7 +82,7 @@ func DefaultByBlockSize(cl SortableClient) {
 // DefaultByAvailability will sort by connection problems received from notifications.
 // Other errors are ignored.
 func DefaultByAvailability(not client.Notification, clients SortableClient) {
-	if !errors.Is(not.Error, client.ErrClientNoConnection) {
+	if !errors.Is(not.Error, client.ErrClientNoConnection) && !errors.Is(not.Error, client.ErrClientTooManyRequests) {
 		return
 	}
 


### PR DESCRIPTION
Tested multiple RPC endpoints they all return a similar error:
Chainstacks:
```
429 Too Many Requests: <html>
<head><title>429 Too Many Requests</title></head>
<body>
```

 infura:
```
429 Too Many Requests: {"jsonrpc":"2.0","id":2,"error":{"cod....
```

maticvigil:
```
429 Too Many Requests: {"error":{"details":"Rate limit exceeded: 40 per 1 second. Check response body for more details on backoff.Sign up for a dedicated RPC plan on https://rpc.maticvi,,,
```

Mapped to a string representation of the error because go-ethereum library doesn't return the underlying error( 😢  ):
```
			buf := new(bytes.Buffer)
			if _, err2 := buf.ReadFrom(respBody); err2 == nil {
				return fmt.Errorf("%v: %v", err, buf.String())
			}
``` 


Extended the default sorter to work with the additional error.