### PR TITLE
Add etherscan and refactor stations for easier usage

### DIFF
--- a/transfer/gas/eth.go
+++ b/transfer/gas/eth.go
@@ -52,28 +52,17 @@ func NewEthStation(apiKey, endpointURI string, upperBound *big.Int) *EthStation 
 	}
 }
 
-func (dpa *EthStation) GetAverageGasPrice() (*big.Int, error) {
+func (dpa *EthStation) GetGasPrices() (*GasPrices, error) {
 	res, err := dpa.defiRequest()
 	if err != nil {
 		return nil, err
 	}
-	return dpa.result(res.Average), nil
-}
-
-func (dpa *EthStation) GetLowGasPrice() (*big.Int, error) {
-	res, err := dpa.defiRequest()
-	if err != nil {
-		return nil, err
+	prices := GasPrices{
+		SafeLow: dpa.result(res.SafeLow),
+		Average: dpa.result(res.Average),
+		Fast:    dpa.result(res.Fast),
 	}
-	return dpa.result(res.SafeLow), nil
-}
-
-func (dpa *EthStation) GetFastGasPrice() (*big.Int, error) {
-	res, err := dpa.defiRequest()
-	if err != nil {
-		return nil, err
-	}
-	return dpa.result(res.Fast), nil
+	return &prices, nil
 }
 
 func (dpa *EthStation) defiRequest() (*GasStationResponse, error) {

--- a/transfer/gas/etherscan.go
+++ b/transfer/gas/etherscan.go
@@ -1,0 +1,134 @@
+package gas
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mysteriumnetwork/payments/units"
+	"github.com/rs/zerolog/log"
+)
+
+// DefaultEtherscanEndpointURI the default etherscan api endpoint.
+const DefaultEtherscanEndpointURI = "https://api.etherscan.io/"
+
+// EtherscanStation represents the etherscan api to retrive gas prices.
+type EtherscanStation struct {
+	APIKey      string
+	EndpointURI string
+	upperBound  *big.Int
+
+	client *http.Client
+}
+
+// NewEtherscanStation returns a new instance of etherscan api for gas price checks.
+func NewEtherscanStation(apiKey, endpointURI string, upperBound *big.Int) *EtherscanStation {
+	endpoint := endpointURI
+	if !strings.HasSuffix(endpoint, "/") {
+		endpoint += "/"
+	}
+
+	return &EtherscanStation{
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		EndpointURI: endpointURI,
+		upperBound:  upperBound,
+		APIKey:      apiKey,
+	}
+}
+
+func (esa *EtherscanStation) GetAverageGasPrice() (*big.Int, error) {
+	res, err := esa.request()
+	if err != nil {
+		return nil, err
+	}
+	value, err := strconv.ParseFloat(res.Result.ProposeGasPrice, 64)
+	if err != nil {
+		return nil, err
+	}
+	return esa.result(value), nil
+}
+
+func (esa *EtherscanStation) GetLowGasPrice() (*big.Int, error) {
+	res, err := esa.request()
+	if err != nil {
+		return nil, err
+	}
+	value, err := strconv.ParseFloat(res.Result.SafeGasPrice, 64)
+	if err != nil {
+		return nil, err
+	}
+	return esa.result(value), nil
+}
+
+func (dpa *EtherscanStation) GetFastGasPrice() (*big.Int, error) {
+	res, err := dpa.request()
+	if err != nil {
+		return nil, err
+	}
+	value, err := strconv.ParseFloat(res.Result.FastGasPrice, 64)
+	if err != nil {
+		return nil, err
+	}
+	return dpa.result(value), nil
+}
+
+func (esa *EtherscanStation) request() (*etherscanGasPriceResponse, error) {
+	if esa.APIKey == "" {
+		log.Warn().Msg("no API key set, rate is limited")
+	}
+
+	response, err := esa.client.Get(fmt.Sprintf("%v%v%v", esa.EndpointURI, "api?module=gastracker&action=gasoracle&apikey=", esa.APIKey))
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	resp, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println(string(resp))
+
+	var res etherscanGasPriceResponse
+	err = json.Unmarshal(resp, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.Status != "1" {
+		return nil, errors.New("etherscan API request failed")
+	}
+
+	return &res, nil
+}
+
+func (esa *EtherscanStation) result(price float64) *big.Int {
+	bp := units.FloatGweiToBigIntWei(price)
+	return priceMaxUpperBound(bp, esa.upperBound)
+}
+
+// etherscanGasPriceResponse returns the gas station response.
+type etherscanGasPriceResponse struct {
+	Status  string         `json:"status"`
+	Message string         `json:"message"`
+	Result  gasPriceResult `json:"result"`
+}
+
+// gasPriceResult the gas prices for the last block.
+type gasPriceResult struct {
+	LastBlock       string `json:"LastBlock"`
+	SafeGasPrice    string `json:"SafeGasPrice"`
+	ProposeGasPrice string `json:"ProposeGasPrice"`
+	FastGasPrice    string `json:"FastGasPrice"`
+	SuggestBaseFee  string `json:"suggestBaseFee"`
+	GasUsedRatio    string `json:"gasUsedRatio"`
+}

--- a/transfer/gas/etherscan.go
+++ b/transfer/gas/etherscan.go
@@ -2,7 +2,6 @@ package gas
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -20,8 +19,8 @@ const DefaultEtherscanEndpointURI = "https://api.etherscan.io/"
 
 // EtherscanStation represents the etherscan api to retrive gas prices.
 type EtherscanStation struct {
-	APIKey      string
-	EndpointURI string
+	apiKey      string
+	endpointURI string
 	upperBound  *big.Int
 
 	client *http.Client
@@ -38,54 +37,43 @@ func NewEtherscanStation(apiKey, endpointURI string, upperBound *big.Int) *Ether
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		EndpointURI: endpointURI,
+		endpointURI: endpointURI,
 		upperBound:  upperBound,
-		APIKey:      apiKey,
+		apiKey:      apiKey,
 	}
 }
 
-func (esa *EtherscanStation) GetAverageGasPrice() (*big.Int, error) {
+func (esa *EtherscanStation) GetGasPrices() (*GasPrices, error) {
 	res, err := esa.request()
 	if err != nil {
 		return nil, err
 	}
-	value, err := strconv.ParseFloat(res.Result.ProposeGasPrice, 64)
+	average, err := strconv.ParseFloat(res.Result.ProposeGasPrice, 64)
 	if err != nil {
 		return nil, err
 	}
-	return esa.result(value), nil
-}
-
-func (esa *EtherscanStation) GetLowGasPrice() (*big.Int, error) {
-	res, err := esa.request()
+	safeLow, err := strconv.ParseFloat(res.Result.SafeGasPrice, 64)
 	if err != nil {
 		return nil, err
 	}
-	value, err := strconv.ParseFloat(res.Result.SafeGasPrice, 64)
+	fast, err := strconv.ParseFloat(res.Result.FastGasPrice, 64)
 	if err != nil {
 		return nil, err
 	}
-	return esa.result(value), nil
-}
-
-func (dpa *EtherscanStation) GetFastGasPrice() (*big.Int, error) {
-	res, err := dpa.request()
-	if err != nil {
-		return nil, err
+	prices := GasPrices{
+		SafeLow: esa.result(safeLow),
+		Average: esa.result(average),
+		Fast:    esa.result(fast),
 	}
-	value, err := strconv.ParseFloat(res.Result.FastGasPrice, 64)
-	if err != nil {
-		return nil, err
-	}
-	return dpa.result(value), nil
+	return &prices, nil
 }
 
 func (esa *EtherscanStation) request() (*etherscanGasPriceResponse, error) {
-	if esa.APIKey == "" {
+	if esa.apiKey == "" {
 		log.Warn().Msg("no API key set, rate is limited")
 	}
 
-	response, err := esa.client.Get(fmt.Sprintf("%v%v%v", esa.EndpointURI, "api?module=gastracker&action=gasoracle&apikey=", esa.APIKey))
+	response, err := esa.client.Get(fmt.Sprintf("%v%v%v", esa.endpointURI, "api?module=gastracker&action=gasoracle&apikey=", esa.apiKey))
 	if err != nil {
 		return nil, err
 	}
@@ -96,16 +84,14 @@ func (esa *EtherscanStation) request() (*etherscanGasPriceResponse, error) {
 		return nil, err
 	}
 
-	fmt.Println(string(resp))
-
 	var res etherscanGasPriceResponse
 	err = json.Unmarshal(resp, &res)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read response body from etherscan with an error: %w and body: %s", err, string(resp))
 	}
 
 	if res.Status != "1" {
-		return nil, errors.New("etherscan API request failed")
+		return nil, fmt.Errorf("etherscan api failed with message: %s", res.Message)
 	}
 
 	return &res, nil
@@ -121,6 +107,12 @@ type etherscanGasPriceResponse struct {
 	Status  string         `json:"status"`
 	Message string         `json:"message"`
 	Result  gasPriceResult `json:"result"`
+}
+
+type etherscanGasPriceResponseFail struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Result  string `json:"result"`
 }
 
 // gasPriceResult the gas prices for the last block.

--- a/transfer/gas/matic.go
+++ b/transfer/gas/matic.go
@@ -41,28 +41,17 @@ func NewMaticStation(apiURL string, upperBound *big.Int) *MaticStation {
 	}
 }
 
-func (m *MaticStation) GetAverageGasPrice() (*big.Int, error) {
+func (m *MaticStation) GetGasPrices() (*GasPrices, error) {
 	resp, err := m.request()
 	if err != nil {
 		return nil, err
 	}
-	return m.result(resp.Standard), nil
-}
-
-func (m *MaticStation) GetLowGasPrice() (*big.Int, error) {
-	resp, err := m.request()
-	if err != nil {
-		return nil, err
+	prices := GasPrices{
+		SafeLow: m.result(resp.SafeLow),
+		Average: m.result(resp.Standard),
+		Fast:    m.result(resp.Fast),
 	}
-	return m.result(resp.SafeLow), nil
-}
-
-func (m *MaticStation) GetFastGasPrice() (*big.Int, error) {
-	resp, err := m.request()
-	if err != nil {
-		return nil, err
-	}
-	return m.result(resp.Fast), nil
+	return &prices, nil
 }
 
 func (m *MaticStation) result(price float64) *big.Int {

--- a/transfer/gas/multichain_station.go
+++ b/transfer/gas/multichain_station.go
@@ -2,36 +2,17 @@ package gas
 
 import (
 	"fmt"
-	"math/big"
 )
 
 // MultichainStation is a station that can hold multiple station
 // and call them depending on the chain given.
 type MultichainStation map[int64]Station
 
-func (m MultichainStation) GetAveragePrice(chainID int64) (*big.Int, error) {
+func (m MultichainStation) GetGasPrices(chainID int64) (*GasPrices, error) {
 	station, ok := m[chainID]
 	if !ok {
 		return nil, fmt.Errorf("no gas station for chain %d", chainID)
 	}
 
-	return station.GetAverageGasPrice()
-}
-
-func (m MultichainStation) GetFastPrice(chainID int64) (*big.Int, error) {
-	station, ok := m[chainID]
-	if !ok {
-		return nil, fmt.Errorf("no gas station for chain %d", chainID)
-	}
-
-	return station.GetFastGasPrice()
-}
-
-func (m MultichainStation) GetLowPrice(chainID int64) (*big.Int, error) {
-	station, ok := m[chainID]
-	if !ok {
-		return nil, fmt.Errorf("no gas station for chain %d", chainID)
-	}
-
-	return station.GetLowGasPrice()
+	return station.GetGasPrices()
 }

--- a/transfer/gas/static.go
+++ b/transfer/gas/static.go
@@ -11,14 +11,11 @@ func NewStaticStation(price *big.Int) *StaticStation {
 	return &StaticStation{staticPrice: price}
 }
 
-func (s *StaticStation) GetAverageGasPrice() (*big.Int, error) {
-	return new(big.Int).Set(s.staticPrice), nil
-}
-
-func (s *StaticStation) GetFastGasPrice() (*big.Int, error) {
-	return new(big.Int).Set(s.staticPrice), nil
-}
-
-func (s *StaticStation) GetLowGasPrice() (*big.Int, error) {
-	return new(big.Int).Set(s.staticPrice), nil
+func (s *StaticStation) GetGasPrices() (*GasPrices, error) {
+	prices := GasPrices{
+		SafeLow: new(big.Int).Set(s.staticPrice),
+		Average: new(big.Int).Set(s.staticPrice),
+		Fast:    new(big.Int).Set(s.staticPrice),
+	}
+	return &prices, nil
 }

--- a/transfer/gas/station.go
+++ b/transfer/gas/station.go
@@ -5,12 +5,14 @@ import "math/big"
 // Station is a gas station inteface that provides methods
 // to get gas prices in a network.
 type Station interface {
-	// GetAverageGasPrice returns the current average gas price.
-	GetAverageGasPrice() (*big.Int, error)
-	// GetLowGasPrice returns the lowest possible suggest gas price.
-	GetLowGasPrice() (*big.Int, error)
-	// GetFastGasPrice returns gas price suggested for fast transactions.
-	GetFastGasPrice() (*big.Int, error)
+	// GetGasPrice returns the gas prices (Low, Average and Fast).
+	GetGasPrices() (*GasPrices, error)
+}
+
+type GasPrices struct {
+	SafeLow *big.Int
+	Average *big.Int
+	Fast    *big.Int
 }
 
 func priceMaxUpperBound(price *big.Int, bound *big.Int) *big.Int {


### PR DESCRIPTION
The functions for getting the different prices (safeLow, average and fast) are now only one, as all API returns them all together. A refactor will be needed in other projects too.

Etherscan is added as an API provider for gas prices.