### PR TITLE
Remake transaction handling

### DIFF
--- a/client/bc.go
+++ b/client/bc.go
@@ -78,6 +78,7 @@ type BC interface {
 	SuggestGasPrice() (*big.Int, error)
 	HeaderByNumber(number *big.Int) (*types.Header, error)
 	PendingNonceAt(account common.Address) (uint64, error)
+	NonceAt(account common.Address, blockNum *big.Int) (uint64, error)
 
 	TransferMyst(req TransferRequest) (tx *types.Transaction, err error)
 	TransferEth(etr EthTransferRequest) (*types.Transaction, error)

--- a/client/client.go
+++ b/client/client.go
@@ -248,6 +248,12 @@ func (bc *Blockchain) PendingNonceAt(account common.Address) (uint64, error) {
 	return bc.ethClient.Client().PendingNonceAt(ctx, account)
 }
 
+func (bc *Blockchain) NonceAt(account common.Address, blockNum *big.Int) (uint64, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), bc.bcTimeout)
+	defer cancel()
+	return bc.ethClient.Client().NonceAt(ctx, account, blockNum)
+}
+
 func (bc *Blockchain) getProviderChannelAddressBytes(hermesAddress, addressToCheck common.Address) ([32]byte, error) {
 	addressBytes := [32]byte{}
 

--- a/client/multichain_client.go
+++ b/client/multichain_client.go
@@ -340,6 +340,14 @@ func (mbc *MultichainBlockchainClient) PendingNonceAt(chainID int64, account com
 	return bc.PendingNonceAt(account)
 }
 
+func (mbc *MultichainBlockchainClient) NonceAt(chainID int64, account common.Address, blockNum *big.Int) (uint64, error) {
+	bc, err := mbc.getClientByChain(chainID)
+	if err != nil {
+		return 0, err
+	}
+	return bc.NonceAt(account, blockNum)
+}
+
 func (mbc *MultichainBlockchainClient) TransferEth(chainID int64, etr EthTransferRequest) (*types.Transaction, error) {
 	bc, err := mbc.getClientByChain(chainID)
 	if err != nil {

--- a/client/with_dry_runs.go
+++ b/client/with_dry_runs.go
@@ -419,3 +419,6 @@ func (cwdr *WithDryRuns) TopperupperTokenLimits(topperupperAddress common.Addres
 func (cwdr *WithDryRuns) PendingNonceAt(account common.Address) (uint64, error) {
 	return cwdr.bc.PendingNonceAt(account)
 }
+func (cwdr *WithDryRuns) NonceAt(account common.Address, blockNum *big.Int) (uint64, error) {
+	return cwdr.bc.NonceAt(account, blockNum)
+}

--- a/transaction/courier/data.go
+++ b/transaction/courier/data.go
@@ -1,0 +1,42 @@
+package courier
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/mysteriumnetwork/payments/transaction"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type transferData struct {
+	Amount *big.Int       `json:"amount"`
+	To     common.Address `json:"to"`
+}
+
+type mystTransferData struct {
+	transferData
+	MystAddress common.Address `json:"myst_address"`
+}
+
+func (d *transferData) validate() error {
+	if d.Amount == nil || d.Amount.Cmp(big.NewInt(0)) == 0 {
+		return fmt.Errorf("amount cannot be 0: %w", transaction.ErrImpossibleToDeliver)
+	}
+	if d.To.Hex() == common.HexToAddress("").Hex() {
+		return fmt.Errorf("recipient address cannot be empty: %w", transaction.ErrImpossibleToDeliver)
+	}
+
+	return nil
+}
+
+func (d *mystTransferData) validate() error {
+	if err := d.transferData.validate(); err != nil {
+		return err
+	}
+	if d.MystAddress.Hex() == common.HexToAddress("").Hex() {
+		return fmt.Errorf("myst address cannot be empty: %w", transaction.ErrImpossibleToDeliver)
+	}
+
+	return nil
+}

--- a/transaction/courier/simple.go
+++ b/transaction/courier/simple.go
@@ -1,0 +1,140 @@
+package courier
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/mysteriumnetwork/payments/client"
+	"github.com/mysteriumnetwork/payments/transaction"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Simple is the default simple courier that implements
+// `transaction.DeliveryCourier` interface. It can handle
+// only the most basic transactions.
+type Simple struct {
+	bc SimpleBCClient
+	sf SignerFactory
+}
+
+type SimpleBCClient interface {
+	TransferMyst(chainID int64, req client.TransferRequest) (*types.Transaction, error)
+	TransferEth(chainID int64, etr client.EthTransferRequest) (*types.Transaction, error)
+}
+
+// SignerFactory given a sender and chain should produce a signature func
+// which can be used to sign transactions.
+type SignerFactory func(sender common.Address, chain int64) transaction.SignFunc
+
+const (
+	deliveryTypeNetworkTransfer transaction.DeliverableType = "network-transfer"
+	deliveryTypeMystTransfer    transaction.DeliverableType = "myst-transfer"
+)
+
+func NewSimpleCourier(bc SimpleBCClient, sf SignerFactory) *Simple {
+	return &Simple{
+		bc: bc,
+		sf: sf,
+	}
+}
+
+func (s *Simple) DeliverTransaction(td transaction.Delivery) (*types.Transaction, error) {
+	fn := s.getDeliveryFunc(td.Type)
+	if fn == nil {
+		return nil, fmt.Errorf("type %q is impossible to handle", td.Type)
+	}
+
+	return fn(td)
+}
+
+func (s *Simple) CanDeliver(typ transaction.DeliverableType) bool {
+	return s.getDeliveryFunc(typ) != nil
+}
+
+func (c *Simple) NewNetworkTransferDelivery(sender transaction.Sender, amount *big.Int, to common.Address) (transaction.DeliveryRequest, error) {
+	nt := transferData{
+		Amount: amount,
+		To:     to,
+	}
+
+	return transaction.DeliveryRequest{
+		ChainID: sender.ChainID,
+		Sender:  sender.Address,
+		Type:    deliveryTypeNetworkTransfer,
+		Data:    nt,
+	}, nt.validate()
+}
+
+func (c *Simple) NewMystTransferDelivery(sender transaction.Sender, amount *big.Int, to common.Address, mystAddr common.Address) (transaction.DeliveryRequest, error) {
+	mt := mystTransferData{
+		transferData: transferData{
+			Amount: amount,
+			To:     to,
+		},
+		MystAddress: mystAddr,
+	}
+
+	return transaction.DeliveryRequest{
+		ChainID: sender.ChainID,
+		Sender:  sender.Address,
+		Type:    deliveryTypeMystTransfer,
+		Data:    mt,
+	}, mt.validate()
+}
+
+func (s *Simple) getDeliveryFunc(typ transaction.DeliverableType) func(transaction.Delivery) (*types.Transaction, error) {
+	switch typ {
+	case deliveryTypeNetworkTransfer:
+		return s.networkTransfer
+	case deliveryTypeMystTransfer:
+		return s.mystTransfer
+	default:
+		return nil
+	}
+}
+
+func (c *Simple) networkTransfer(td transaction.Delivery) (*types.Transaction, error) {
+	wr := td.ToWriteRequest(c.sf(td.Sender, td.ChainID), 50000)
+
+	var extra transferData
+	if err := json.Unmarshal(td.ShipmentData, &extra); err != nil {
+		return nil, err
+	}
+
+	if err := extra.validate(); err != nil {
+		return nil, err
+	}
+
+	request := client.EthTransferRequest{
+		WriteRequest: wr,
+		Amount:       extra.Amount,
+		To:           extra.To,
+	}
+
+	return c.bc.TransferEth(td.ChainID, request)
+}
+
+func (c *Simple) mystTransfer(td transaction.Delivery) (*types.Transaction, error) {
+	wr := td.ToWriteRequest(c.sf(td.Sender, td.ChainID), 100000)
+
+	var extra mystTransferData
+	if err := json.Unmarshal(td.ShipmentData, &extra); err != nil {
+		return nil, err
+	}
+
+	if err := extra.validate(); err != nil {
+		return nil, err
+	}
+
+	request := client.TransferRequest{
+		WriteRequest: wr,
+		Amount:       extra.Amount,
+		Recipient:    extra.To,
+		MystAddress:  extra.MystAddress,
+	}
+
+	return c.bc.TransferMyst(td.ChainID, request)
+}

--- a/transaction/delivery.go
+++ b/transaction/delivery.go
@@ -1,0 +1,133 @@
+/* Mysterium network payment library.
+ *
+ * Copyright (C) 2021 BlockDev AG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package transaction
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/mysteriumnetwork/payments/client"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+type Delivery struct {
+	UniqueID string
+	Sender   common.Address
+
+	Nonce    uint64
+	ChainID  int64
+	GasPrice *big.Int
+
+	Type  DeliverableType
+	State DeliveryState
+
+	ShipmentData    []byte
+	SentTransaction []byte
+
+	CreatedUTC time.Time
+	UpdateUTC  time.Time
+}
+
+// DeliverableType is issued for the Courier to determine how to package a transaction.
+type DeliverableType string
+
+type DeliveryState string
+
+const (
+	// Waiting is state for transaction which were never sent
+	DeliveryStateWaiting = "waiting"
+	// DeliveryStatePacking is state for transaction that were or are
+	// being attempted to be send but no confirmation about them leaving is received.
+	DeliveryStatePacking = "packing"
+	// DeliveryStateSent is a state for transaction that are for sure sent
+	// and we can track them, raising gas price if needed.
+	DeliveryStateSent = "sent"
+	// DeliveryStateDelivered is state for transaction that have been delivered
+	// and we will no longer track it.
+	DeliveryStateDelivered = "delivered"
+)
+
+var ErrNoTrasactionExists = errors.New("transaction doesn't exist")
+
+type SignFunc func(common.Address, *types.Transaction) (*types.Transaction, error)
+
+// ToWriteRequest will convert a Delivery to a typical write request used by `client` package.
+func (t *Delivery) ToWriteRequest(signer SignFunc, gasLimit uint64) client.WriteRequest {
+	return client.WriteRequest{
+		Identity: t.Sender,
+		Signer:   bind.SignerFn(signer),
+		GasLimit: gasLimit,
+		GasPrice: t.GasPrice,
+		Nonce:    new(big.Int).SetUint64(t.Nonce),
+	}
+}
+
+func (t *Delivery) GetLastTransaction() (*types.Transaction, error) {
+	if len(t.SentTransaction) == 0 {
+		return nil, ErrNoTrasactionExists
+	}
+
+	tx := &types.Transaction{}
+	return tx, tx.UnmarshalJSON(t.SentTransaction)
+}
+
+type DeliveryRequest struct {
+	ChainID int64
+	Sender  common.Address
+
+	Type DeliverableType
+
+	// Data must always be a marshable struct or nil
+	Data interface{}
+}
+
+func (t *DeliveryRequest) toDelivery(nonce uint64) (Delivery, error) {
+	now := time.Now().UTC()
+
+	if t.Data == nil {
+		t.Data = struct{}{}
+	}
+
+	blob, err := json.Marshal(t.Data)
+	if err != nil {
+		return Delivery{}, err
+	}
+
+	return Delivery{
+		UniqueID: fmt.Sprintf("%s|%d|%d", t.Sender.Hex(), nonce, t.ChainID),
+		Sender:   t.Sender,
+
+		Nonce:    nonce,
+		ChainID:  t.ChainID,
+		GasPrice: new(big.Int).SetInt64(0),
+
+		Type:  t.Type,
+		State: DeliveryStateWaiting,
+
+		ShipmentData:    blob,
+		SentTransaction: []byte{},
+
+		CreatedUTC: now,
+		UpdateUTC:  now,
+	}, nil
+}

--- a/transaction/depot.go
+++ b/transaction/depot.go
@@ -1,0 +1,333 @@
+/* Mysterium network payment library.
+ *
+ * Copyright (C) 2021 BlockDev AG
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package transaction
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// Depot is a transaction delivery depot. Using a given `DeliveryCourier`
+// it will try to deliver transactions to the blockchain.
+//
+// Upon successfull dispatch it will track transactions making
+// sure that they reach their destination. If they're stuck
+// it will reissue a transaction with more gas.
+type Depot struct {
+	handler DeliveryCourier
+	storage DepotStorage
+
+	gasStation   *GasTracker
+	nonceTracker *DepotNonceTracker
+
+	workers []DepotWorker
+
+	logFn func(error)
+	once  sync.Once
+	stop  chan struct{}
+}
+
+// DepotWorker is a worker that will spawn upon starting `Run`.
+// Each worker is reponsible for its own transactions only.
+type DepotWorker struct {
+	Address         common.Address
+	ChainID         int64
+	ProcessInterval time.Duration
+	QueueSize       uint
+}
+
+// DeliveryCourier is responsible for executing transaction on the blockchain.
+// It should be able to send and resend the same transaction multiple times.
+// If it cannot handle a transaction, it will remain in the depot.
+type DeliveryCourier interface {
+	// DeliverTransaction should determine the transaction type and try to delivery it.
+	DeliverTransaction(tx Delivery) (*types.Transaction, error)
+	// CanDeliver should validate the given type and see if the courier will be able to delivery it.
+	// If returned false, transaction will not be queued.
+	CanDeliver(DeliverableType) bool
+}
+
+// DepotStorage is a persistent storage used to keep track of work to do.
+type DepotStorage interface {
+	// GetOrderedDeliveryRequests should return a list of delivery requests ordered by nonce, from lowest to highest.
+	GetOrderedDeliveryRequests(count uint, chainID int64, sender common.Address) ([]Delivery, error)
+	// GetLastQueuedDelivery is used to track nonce
+	GetLastQueuedDelivery(chainID int64, sender common.Address) (*Delivery, error)
+	// GetLastDelivered is used to check when the last transaction was delivered.
+	// It will be used to determine the next time we need to increase gas price.
+	GetLastDelivered(chainID int64, sender common.Address) (*Delivery, error)
+
+	// UpsertDeliveryRequest is used to update a delivery. If no delivery with a given
+	// unique ID exists, it should create it.
+	UpsertDeliveryRequest(tx Delivery) error
+}
+
+var ErrImpossibleToDeliver = errors.New("impossible to deliver")
+
+// NewDepot will returns a new depot.
+func NewDepot(handler DeliveryCourier, storage DepotStorage, nonce *DepotNonceTracker, gasStation *GasTracker, workers []DepotWorker, logFn func(error)) *Depot {
+	return &Depot{
+		handler:      handler,
+		storage:      storage,
+		nonceTracker: nonce,
+		gasStation:   gasStation,
+
+		workers: workers,
+
+		logFn: logFn,
+		stop:  make(chan struct{}),
+	}
+}
+
+// Run will spawn a goroutine for each loaded `DepotWorker`.
+func (d *Depot) Run() {
+	for _, s := range d.workers {
+		go d.watchDeliveries(s)
+	}
+}
+
+// EnqueueDelivery will submit a new transaction to the delivery queue.
+// It will return a unique tracking number which can be used to see the status of a transaction.
+func (d *Depot) EnqueueDelivery(req DeliveryRequest) (string, error) {
+	nonce, err := d.nonceTracker.GetNextNonce(req.ChainID, req.Sender)
+	if err != nil {
+		return "", fmt.Errorf("failed to issue a nonce for a transaction delivery: %w", err)
+	}
+
+	if !d.workerExists(req) {
+		return "", fmt.Errorf("failed to enqueue for sender %q: no worker found", req.Sender.Hex())
+	}
+
+	if !d.handler.CanDeliver(req.Type) {
+		return "", fmt.Errorf("transaction will not set in queue, not possible to delivery type %q", req.Type)
+	}
+
+	td, err := req.toDelivery(nonce)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal queue entry: %w", err)
+	}
+
+	if err := d.storage.UpsertDeliveryRequest(td); err != nil {
+		return "", fmt.Errorf("failed to insert a delivery request: %w", err)
+	}
+
+	return td.UniqueID, nil
+}
+
+// Stop will stop the Deposit goroutines.
+func (d *Depot) Stop() {
+	d.once.Do(func() {
+		close(d.stop)
+	})
+}
+
+// AttachLogger allows the caller to attach an optional logger.
+// Logger logs non critical errors that happen during transaction
+// handling and will be eventually handled by the Depot.
+//
+// This method is not thread safe and should be called before `Run`.
+func (d *Depot) AttachLogger(fn func(err error)) {
+	d.logFn = fn
+}
+
+func (d *Depot) workerExists(req DeliveryRequest) bool {
+	for _, s := range d.workers {
+		if s.Address.Hex() == req.Sender.Hex() && req.ChainID == s.ChainID {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (d *Depot) watchDeliveries(s DepotWorker) {
+	for {
+		select {
+		case <-d.stop:
+			return
+		case <-time.After(s.ProcessInterval):
+			tds, err := d.storage.GetOrderedDeliveryRequests(s.QueueSize, s.ChainID, s.Address)
+			if err != nil {
+				d.logFn(err)
+				break
+			}
+
+			for _, td := range tds {
+				select {
+				case <-d.stop:
+					return
+				default:
+					d.handleDeliveryRequest(td)
+				}
+			}
+		}
+	}
+}
+
+func (d *Depot) handleDeliveryRequest(td Delivery) {
+	switch td.State {
+	case DeliveryStateWaiting:
+		if err := d.handleWaiting(td); err != nil {
+			d.logFn(err)
+		}
+	case DeliveryStatePacking, DeliveryStateSent:
+		if err := d.handleTrackingRequired(td); err != nil {
+			d.logFn(err)
+		}
+	}
+}
+
+func (d *Depot) handleTrackingRequired(td Delivery) error {
+	currentNonce, err := d.nonceTracker.GetConfirmedNonce(td.ChainID, td.Sender)
+	if err != nil {
+		return err
+	}
+
+	// If our nonce increased that means someone is aware about this transaction
+	// and we can continue.
+	if currentNonce >= td.Nonce {
+		if td.State == DeliveryStateWaiting {
+			return fmt.Errorf("refusing to confirm transaction as it was never sent from our side: %q", td.UniqueID)
+		}
+
+		if _, err := d.markDeliveryAsDelivered(td); err != nil {
+			return fmt.Errorf("failed to mark delivery as sent: %w", err)
+		}
+
+		return nil
+	}
+
+	// Only try to resubmit the earliest transaction sent.
+	// Other transactions might have enough gas and this
+	// might be the only blocking transaction.
+	if currentNonce+1 != td.Nonce {
+		return nil
+	}
+
+	ld, err := d.storage.GetLastDelivered(td.ChainID, td.Sender)
+	if err != nil {
+		return fmt.Errorf("failed to get last delivered: %w", err)
+	}
+
+	lastTime := td.UpdateUTC
+	if ld != nil {
+		lastTime = ld.UpdateUTC
+	}
+
+	ok, err := d.gasStation.CanReceiveMoreGas(td.ChainID, lastTime)
+	if err != nil {
+		return fmt.Errorf("tried to redeliver, but got err: %w", err)
+	}
+
+	// We can only resend a transaction only if we give more gas
+	// because if not, it will simply get rejected by the node
+	// as you cannot replace a transaction without giving more gas.
+	if ok {
+		return d.sendOutTransaction(td)
+	}
+
+	return nil
+}
+
+func (d *Depot) handleWaiting(td Delivery) error {
+	if _, err := d.markDeliveryAsPacking(td); err != nil {
+		return fmt.Errorf("failed to mark packing for sender %q reason: %w", td.Sender.Hex(), err)
+	}
+
+	return d.sendOutTransaction(td)
+}
+
+func (d *Depot) sendOutTransaction(td Delivery) error {
+	var err error
+	td, err = d.deliveryRecalculateAndSaveGasPrice(td)
+	if err != nil {
+		return err
+	}
+
+	tx, err := d.handler.DeliverTransaction(td)
+	if err != nil {
+		return fmt.Errorf("attempted to delivery a transaction %q for account %q but failed: %w", td.UniqueID, td.Sender.Hex(), err)
+	}
+
+	if _, err := d.markDeliveryAsSent(td, tx); err != nil {
+		return fmt.Errorf("failed to mark delivery as sent: %w", err)
+	}
+
+	return nil
+}
+
+func (d *Depot) log(err error) {
+	if d.logFn != nil {
+		d.logFn(err)
+	}
+}
+
+func (d *Depot) deliveryRecalculateAndSaveGasPrice(td Delivery) (Delivery, error) {
+	gas, err := d.gasStation.RecalculateDeliveryGas(td.ChainID, td.GasPrice)
+	if err != nil {
+		return td, fmt.Errorf("failed to calculate gas price: %w", err)
+	}
+
+	td.GasPrice = gas
+	td.UpdateUTC = time.Now().UTC()
+	if err := d.storage.UpsertDeliveryRequest(td); err != nil {
+		return td, fmt.Errorf("failed to mark delivery as packing: %w", err)
+	}
+
+	return td, nil
+}
+
+func (d *Depot) markDeliveryAsPacking(td Delivery) (Delivery, error) {
+	td.State = DeliveryStatePacking
+	td.UpdateUTC = time.Now().UTC()
+	if err := d.storage.UpsertDeliveryRequest(td); err != nil {
+		return td, fmt.Errorf("failed to mark delivery as packing: %w", err)
+	}
+
+	return td, nil
+}
+
+func (d *Depot) markDeliveryAsDelivered(td Delivery) (Delivery, error) {
+	td.State = DeliveryStateDelivered
+	td.UpdateUTC = time.Now().UTC()
+	if err := d.storage.UpsertDeliveryRequest(td); err != nil {
+		return td, fmt.Errorf("failed to mark delivery as sent: %w", err)
+	}
+
+	return td, nil
+}
+
+func (d *Depot) markDeliveryAsSent(td Delivery, tx *types.Transaction) (Delivery, error) {
+	marshaled, err := tx.MarshalJSON()
+	if err != nil {
+		return td, err
+	}
+
+	td.State = DeliveryStateSent
+	td.SentTransaction = marshaled
+	td.UpdateUTC = time.Now().UTC()
+	if err := d.storage.UpsertDeliveryRequest(td); err != nil {
+		return td, fmt.Errorf("failed to mark delivery as sent: %w", err)
+	}
+
+	return td, nil
+}

--- a/transaction/gas/eth.go
+++ b/transaction/gas/eth.go
@@ -1,0 +1,171 @@
+package gas
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mysteriumnetwork/payments/units"
+)
+
+// DefaultDefiPulseEndpointURI the default defipulse api endpoint.
+const DefaultDefiPulseEndpointURI = "https://data-api.defipulse.com/api/v1/"
+
+// EthStation represents the defi pulse api to retrive gas prices.
+type EthStation struct {
+	APIKey      string
+	EndpointURI string
+	upperBound  *big.Int
+
+	client *http.Client
+}
+
+// NewEthStation returns a new instance of defi pulse api for gas price checks.
+func NewEthStation(timeout time.Duration, apiKey, endpointURI string, upperBound *big.Int) *EthStation {
+	endpoint := endpointURI
+	if !strings.HasSuffix(endpoint, "/") {
+		endpoint += "/"
+	}
+
+	return &EthStation{
+		client: &http.Client{
+			Transport: &http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout:   10 * time.Second,
+					KeepAlive: 5 * time.Second,
+				}).DialContext,
+				TLSHandshakeTimeout:   5 * time.Second,
+				ExpectContinueTimeout: 4 * time.Second,
+				ResponseHeaderTimeout: 3 * time.Second,
+			},
+			Timeout: timeout,
+		},
+		APIKey:      apiKey,
+		EndpointURI: endpoint,
+		upperBound:  upperBound,
+	}
+}
+
+func (dpa *EthStation) GetGasPrices() (*GasPrices, error) {
+	res, err := dpa.defiRequest()
+	if err != nil {
+		return nil, err
+	}
+	prices := GasPrices{
+		SafeLow: dpa.result(res.SafeLow),
+		Average: dpa.result(res.Average),
+		Fast:    dpa.result(res.Fast),
+	}
+	return &prices, nil
+}
+
+func (dpa *EthStation) defiRequest() (*GasStationResponse, error) {
+	if dpa.APIKey == "" {
+		return nil, errors.New("no API key set, can't use eth gas station")
+	}
+
+	response, err := dpa.client.Get(fmt.Sprintf("%v%v%v", dpa.EndpointURI, "egs/api/ethgasAPI.json?api-key=", dpa.APIKey))
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	resp, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	res := GasStationResponse{}
+	err = json.Unmarshal(resp, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}
+
+func (dpa *EthStation) result(p float64) *big.Int {
+	pb := p / 10.0
+	return priceMaxUpperBound(units.FloatGweiToBigIntWei(pb), dpa.upperBound)
+}
+
+// GasStationResponse returns the gas station response.
+type GasStationResponse struct {
+	Fast          float64       `json:"fast"`
+	Fastest       float64       `json:"fastest"`
+	SafeLow       float64       `json:"safeLow"`
+	Average       float64       `json:"average"`
+	BlockTime     float64       `json:"block_time"`
+	BlockNum      int64         `json:"blockNum"`
+	Speed         float64       `json:"speed"`
+	SafeLowWait   float64       `json:"safeLowWait"`
+	AvgWait       float64       `json:"avgWait"`
+	FastWait      float64       `json:"fastWait"`
+	FastestWait   float64       `json:"fastestWait"`
+	GasPriceRange GasPriceRange `json:"gasPriceRange"`
+}
+
+// GasPriceRange the gas price range report.
+type GasPriceRange struct {
+	Num4   float64 `json:"4"`
+	Num6   float64 `json:"6"`
+	Num8   float64 `json:"8"`
+	Num10  float64 `json:"10"`
+	Num20  float64 `json:"20"`
+	Num30  float64 `json:"30"`
+	Num40  float64 `json:"40"`
+	Num50  float64 `json:"50"`
+	Num60  float64 `json:"60"`
+	Num70  float64 `json:"70"`
+	Num80  float64 `json:"80"`
+	Num90  float64 `json:"90"`
+	Num100 float64 `json:"100"`
+	Num110 float64 `json:"110"`
+	Num120 float64 `json:"120"`
+	Num130 float64 `json:"130"`
+	Num140 float64 `json:"140"`
+	Num150 float64 `json:"150"`
+	Num160 float64 `json:"160"`
+	Num170 float64 `json:"170"`
+	Num180 float64 `json:"180"`
+	Num190 float64 `json:"190"`
+	Num200 float64 `json:"200"`
+	Num220 float64 `json:"220"`
+	Num240 float64 `json:"240"`
+	Num260 float64 `json:"260"`
+	Num280 float64 `json:"280"`
+	Num300 float64 `json:"300"`
+	Num320 float64 `json:"320"`
+	Num340 float64 `json:"340"`
+	Num360 float64 `json:"360"`
+	Num380 float64 `json:"380"`
+	Num400 float64 `json:"400"`
+	Num420 float64 `json:"420"`
+	Num440 float64 `json:"440"`
+	Num460 float64 `json:"460"`
+	Num480 float64 `json:"480"`
+	Num500 float64 `json:"500"`
+	Num520 float64 `json:"520"`
+	Num540 float64 `json:"540"`
+	Num560 float64 `json:"560"`
+	Num570 float64 `json:"570"`
+	Num580 float64 `json:"580"`
+	Num600 float64 `json:"600"`
+	Num620 float64 `json:"620"`
+	Num640 float64 `json:"640"`
+	Num660 float64 `json:"660"`
+	Num680 float64 `json:"680"`
+	Num700 float64 `json:"700"`
+	Num720 float64 `json:"720"`
+	Num740 float64 `json:"740"`
+	Num760 float64 `json:"760"`
+	Num780 float64 `json:"780"`
+	Num800 float64 `json:"800"`
+	Num820 float64 `json:"820"`
+}

--- a/transaction/gas/etherscan.go
+++ b/transaction/gas/etherscan.go
@@ -1,0 +1,126 @@
+package gas
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mysteriumnetwork/payments/units"
+	"github.com/rs/zerolog/log"
+)
+
+// DefaultEtherscanEndpointURI the default etherscan api endpoint.
+const DefaultEtherscanEndpointURI = "https://api.etherscan.io/"
+
+// EtherscanStation represents the etherscan api to retrive gas prices.
+type EtherscanStation struct {
+	apiKey      string
+	endpointURI string
+	upperBound  *big.Int
+
+	client *http.Client
+}
+
+// NewEtherscanStation returns a new instance of etherscan api for gas price checks.
+func NewEtherscanStation(timeout time.Duration, apiKey, endpointURI string, upperBound *big.Int) *EtherscanStation {
+	endpoint := endpointURI
+	if !strings.HasSuffix(endpoint, "/") {
+		endpoint += "/"
+	}
+
+	return &EtherscanStation{
+		client: &http.Client{
+			Timeout: timeout,
+		},
+		endpointURI: endpointURI,
+		upperBound:  upperBound,
+		apiKey:      apiKey,
+	}
+}
+
+func (esa *EtherscanStation) GetGasPrices() (*GasPrices, error) {
+	res, err := esa.request()
+	if err != nil {
+		return nil, err
+	}
+	average, err := strconv.ParseFloat(res.Result.ProposeGasPrice, 64)
+	if err != nil {
+		return nil, err
+	}
+	safeLow, err := strconv.ParseFloat(res.Result.SafeGasPrice, 64)
+	if err != nil {
+		return nil, err
+	}
+	fast, err := strconv.ParseFloat(res.Result.FastGasPrice, 64)
+	if err != nil {
+		return nil, err
+	}
+	prices := GasPrices{
+		SafeLow: esa.result(safeLow),
+		Average: esa.result(average),
+		Fast:    esa.result(fast),
+	}
+	return &prices, nil
+}
+
+func (esa *EtherscanStation) request() (*etherscanGasPriceResponse, error) {
+	if esa.apiKey == "" {
+		log.Warn().Msg("no API key set, rate is limited")
+	}
+
+	response, err := esa.client.Get(fmt.Sprintf("%v%v%v", esa.endpointURI, "api?module=gastracker&action=gasoracle&apikey=", esa.apiKey))
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	resp, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var res etherscanGasPriceResponse
+	err = json.Unmarshal(resp, &res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body from etherscan with an error: %w and body: %s", err, string(resp))
+	}
+
+	if res.Status != "1" {
+		return nil, fmt.Errorf("etherscan api failed with message: %s", res.Message)
+	}
+
+	return &res, nil
+}
+
+func (esa *EtherscanStation) result(price float64) *big.Int {
+	bp := units.FloatGweiToBigIntWei(price)
+	return priceMaxUpperBound(bp, esa.upperBound)
+}
+
+// etherscanGasPriceResponse returns the gas station response.
+type etherscanGasPriceResponse struct {
+	Status  string         `json:"status"`
+	Message string         `json:"message"`
+	Result  gasPriceResult `json:"result"`
+}
+
+type etherscanGasPriceResponseFail struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Result  string `json:"result"`
+}
+
+// gasPriceResult the gas prices for the last block.
+type gasPriceResult struct {
+	LastBlock       string `json:"LastBlock"`
+	SafeGasPrice    string `json:"SafeGasPrice"`
+	ProposeGasPrice string `json:"ProposeGasPrice"`
+	FastGasPrice    string `json:"FastGasPrice"`
+	SuggestBaseFee  string `json:"suggestBaseFee"`
+	GasUsedRatio    string `json:"gasUsedRatio"`
+}

--- a/transaction/gas/matic.go
+++ b/transaction/gas/matic.go
@@ -1,0 +1,81 @@
+package gas
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/mysteriumnetwork/payments/units"
+)
+
+// DefaultMaticStationURI is the default gas station URL that can be used in matic gas station.
+// Default URL is for mainnet of matic gas station service.
+const DefaultMaticStationURI = "https://gasstation-mainnet.matic.network"
+
+// MaticStation represents matic gas station api.
+type MaticStation struct {
+	apiURL     string
+	client     *http.Client
+	upperBound *big.Int
+}
+
+type maticGasPriceResp struct {
+	SafeLow     float64 `json:"safeLow"`
+	Standard    float64 `json:"standard"`
+	Fast        float64 `json:"fast"`
+	Fastest     float64 `json:"fastest"`
+	BlockTime   int     `json:"blockTime"`
+	BlockNumber int     `json:"blockNumber"`
+}
+
+// NewMaticStation returns a new instance of matic gas station which can be used for gas price checks.
+func NewMaticStation(apiURL string, upperBound *big.Int) *MaticStation {
+	return &MaticStation{
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		apiURL:     apiURL,
+		upperBound: upperBound,
+	}
+}
+
+func (m *MaticStation) GetGasPrices() (*GasPrices, error) {
+	resp, err := m.request()
+	if err != nil {
+		return nil, err
+	}
+	prices := GasPrices{
+		SafeLow: m.result(resp.SafeLow),
+		Average: m.result(resp.Standard),
+		Fast:    m.result(resp.Fast),
+	}
+	return &prices, nil
+}
+
+func (m *MaticStation) result(price float64) *big.Int {
+	bp := units.FloatGweiToBigIntWei(price)
+	return priceMaxUpperBound(bp, m.upperBound)
+}
+
+func (m *MaticStation) request() (*maticGasPriceResp, error) {
+	resp, err := m.client.Get(m.apiURL)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var price maticGasPriceResp
+	if err := json.Unmarshal(body, &price); err != nil {
+		return nil, err
+	}
+
+	return &price, nil
+}

--- a/transaction/gas/multichain_station.go
+++ b/transaction/gas/multichain_station.go
@@ -1,0 +1,29 @@
+package gas
+
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+)
+
+// MultichainStation is a station that can hold multiple station
+// and call them depending on the chain given.
+type MultichainStation map[int64][]Station
+
+func (m MultichainStation) GetGasPrices(chainID int64) (*GasPrices, error) {
+	stations, ok := m[chainID]
+	if !ok {
+		return nil, fmt.Errorf("no gas stations for chain %d", chainID)
+	}
+
+	for i, station := range stations {
+		prices, err := station.GetGasPrices()
+		if err != nil {
+			log.Err(err).Int64("chainID", chainID).Int("stationIndex", i).Msg("failed to get gas prices")
+			continue
+		}
+		return prices, nil
+	}
+
+	return nil, fmt.Errorf("all gas station for chain %d failed", chainID)
+}

--- a/transaction/gas/multichain_station_test.go
+++ b/transaction/gas/multichain_station_test.go
@@ -1,0 +1,58 @@
+package gas
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultichain(t *testing.T) {
+	t.Run("green path", func(t *testing.T) {
+		defaultPrice := big.NewInt(10)
+		mq := MultichainStation{
+			1: []Station{NewStaticStation(defaultPrice), NewStaticStation(big.NewInt(600))},
+		}
+
+		prices, err := mq.GetGasPrices(1)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultPrice, prices.Average)
+		assert.Equal(t, defaultPrice, prices.SafeLow)
+		assert.Equal(t, defaultPrice, prices.Fast)
+	})
+	t.Run("fallback", func(t *testing.T) {
+		defaultPrice := big.NewInt(10)
+		mq := MultichainStation{
+			1: []Station{NewFailingStationMock(), NewStaticStation(defaultPrice)},
+		}
+
+		prices, err := mq.GetGasPrices(1)
+		assert.NoError(t, err)
+		assert.Equal(t, defaultPrice, prices.Average)
+		assert.Equal(t, defaultPrice, prices.SafeLow)
+		assert.Equal(t, defaultPrice, prices.Fast)
+	})
+	t.Run("chain does not exist", func(t *testing.T) {
+		defaultPrice := big.NewInt(10)
+		mq := MultichainStation{
+			1: []Station{NewFailingStationMock(), NewStaticStation(defaultPrice)},
+		}
+		prices, err := mq.GetGasPrices(2)
+
+		assert.Equal(t, fmt.Sprint(err), "no gas stations for chain 2")
+		assert.Nil(t, prices)
+	})
+}
+
+type FailingStationMock struct {
+}
+
+func NewFailingStationMock() *FailingStationMock {
+	return &FailingStationMock{}
+}
+
+func (mock *FailingStationMock) GetGasPrices() (*GasPrices, error) {
+	return nil, errors.New("mock error")
+}

--- a/transaction/gas/static.go
+++ b/transaction/gas/static.go
@@ -1,0 +1,21 @@
+package gas
+
+import "math/big"
+
+// StaticStation returns static non changing gas price.
+type StaticStation struct {
+	staticPrice *big.Int
+}
+
+func NewStaticStation(price *big.Int) *StaticStation {
+	return &StaticStation{staticPrice: price}
+}
+
+func (s *StaticStation) GetGasPrices() (*GasPrices, error) {
+	prices := GasPrices{
+		SafeLow: new(big.Int).Set(s.staticPrice),
+		Average: new(big.Int).Set(s.staticPrice),
+		Fast:    new(big.Int).Set(s.staticPrice),
+	}
+	return &prices, nil
+}

--- a/transaction/gas/station.go
+++ b/transaction/gas/station.go
@@ -1,0 +1,23 @@
+package gas
+
+import "math/big"
+
+// Station is a gas station inteface that provides methods
+// to get gas prices in a network.
+type Station interface {
+	// GetGasPrice returns the gas prices (Low, Average and Fast).
+	GetGasPrices() (*GasPrices, error)
+}
+
+type GasPrices struct {
+	SafeLow *big.Int
+	Average *big.Int
+	Fast    *big.Int
+}
+
+func priceMaxUpperBound(price *big.Int, bound *big.Int) *big.Int {
+	if price.Cmp(bound) > 0 {
+		return bound
+	}
+	return price
+}

--- a/transaction/gas_tracker.go
+++ b/transaction/gas_tracker.go
@@ -1,0 +1,100 @@
+package transaction
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/mysteriumnetwork/payments/transaction/gas"
+)
+
+type GasTracker struct {
+	gs   GasStation
+	opts map[int64]GasIncreaseOpts
+
+	speed GasTrackerSpeed
+}
+
+type GasIncreaseOpts struct {
+	Multiplier       float64
+	PriceLimit       *big.Int
+	IncreaseInterval time.Duration
+}
+
+type GasStation interface {
+	GetGasPrices(chainID int64) (*gas.GasPrices, error)
+}
+
+type GasTrackerSpeed string
+
+const (
+	GasTrackerSpeedSlow   GasTrackerSpeed = "slow"
+	GasTrackerSpeedMedium GasTrackerSpeed = "medium"
+	GasTrackerSpeedFast   GasTrackerSpeed = "fast"
+)
+
+func NewGasTracker(gs GasStation, opts map[int64]GasIncreaseOpts, speed GasTrackerSpeed) *GasTracker {
+	return &GasTracker{
+		gs:    gs,
+		opts:  opts,
+		speed: speed,
+	}
+}
+
+func (g *GasTracker) initialDeliveryGas(chainID int64) (*big.Int, error) {
+	prices, err := g.gs.GetGasPrices(chainID)
+	if err != nil {
+		return nil, err
+	}
+
+	switch g.speed {
+	case GasTrackerSpeedSlow:
+		return prices.SafeLow, nil
+	case GasTrackerSpeedMedium:
+		return prices.Average, nil
+	case GasTrackerSpeedFast:
+		return prices.Fast, nil
+	}
+
+	return nil, errors.New("gas station not configured")
+}
+
+func (g *GasTracker) CanReceiveMoreGas(chainID int64, lastFillUpUTC time.Time) (bool, error) {
+	opts, ok := g.opts[chainID]
+	if !ok {
+		return false, fmt.Errorf("no opts for chain %d", chainID)
+	}
+
+	receiveAfter := lastFillUpUTC.Add(opts.IncreaseInterval)
+	return time.Now().UTC().After(receiveAfter), nil
+}
+
+func (g *GasTracker) RecalculateDeliveryGas(chainID int64, lastKnownGas *big.Int) (*big.Int, error) {
+	if lastKnownGas == nil || lastKnownGas.Cmp(big.NewInt(0)) <= 0 {
+		return g.initialDeliveryGas(chainID)
+	}
+
+	opts, ok := g.opts[chainID]
+	if !ok {
+		return nil, fmt.Errorf("no opts for chain %d", chainID)
+	}
+
+	newGasPrice, _ := new(big.Float).Mul(
+		big.NewFloat(opts.Multiplier),
+		new(big.Float).SetInt(lastKnownGas),
+	).Int(nil)
+	if newGasPrice == nil {
+		return opts.PriceLimit, nil
+	}
+
+	if newGasPrice.Cmp(opts.PriceLimit) > 0 {
+		if lastKnownGas.Cmp(opts.PriceLimit) < 0 {
+			return opts.PriceLimit, nil
+		}
+
+		return nil, errors.New("max price reached, cannot increase")
+	}
+
+	return newGasPrice, nil
+}

--- a/transaction/nonce_tracker.go
+++ b/transaction/nonce_tracker.go
@@ -1,0 +1,85 @@
+package transaction
+
+import (
+	"math/big"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// DepotNonceTracker keeps track of nonces atomically.
+type DepotNonceTracker struct {
+	nonceTrackerBC nonceTrackerBC
+	ds             DepotStorage
+
+	nonces    map[Sender]uint64
+	nonceLock sync.Mutex
+}
+
+type nonceTrackerBC interface {
+	PendingNonceAt(chainID int64, account common.Address) (uint64, error)
+	NonceAt(chainID int64, account common.Address, blockNum *big.Int) (uint64, error)
+}
+
+// NewDepotNonceTracker returns a new nonce tracker.
+func NewDepotNonceTracker(nonceTrackerBC nonceTrackerBC, ds DepotStorage) *DepotNonceTracker {
+	return &DepotNonceTracker{
+		nonceTrackerBC: nonceTrackerBC,
+		nonces:         make(map[Sender]uint64),
+		ds:             ds,
+	}
+}
+
+// GetNextNonce returns an atomically increasing nonce for the account.
+func (nt *DepotNonceTracker) GetNextNonce(chainID int64, account common.Address) (uint64, error) {
+	nt.nonceLock.Lock()
+	defer nt.nonceLock.Unlock()
+
+	key := NewSender(account, chainID)
+	if v, ok := nt.nonces[key]; ok {
+		v++
+		nt.nonces[key] = v
+		return v, nil
+	}
+
+	lastKnown, err := nt.ds.GetLastQueuedDelivery(chainID, account)
+	if err != nil {
+		return 0, err
+	}
+
+	persistentNonce := uint64(0)
+	if lastKnown != nil {
+		persistentNonce = lastKnown.Nonce + 1
+	}
+
+	bcNonce, err := nt.nonceTrackerBC.PendingNonceAt(chainID, account)
+	if err != nil {
+		return bcNonce, err
+	}
+
+	nonce := persistentNonce
+	if bcNonce > persistentNonce {
+		// If BC nonce is larger, that means we've missed some transaction and didnt account for them
+		// in the persistent storage. Issue a nonce that is up to date.
+		nonce = bcNonce
+	}
+
+	nt.nonces[key] = nonce
+	return nonce, nil
+}
+
+func (nt *DepotNonceTracker) GetConfirmedNonce(chainID int64, account common.Address) (uint64, error) {
+	bcNonce, err := nt.nonceTrackerBC.NonceAt(chainID, account, nil)
+	if err != nil {
+		return bcNonce, err
+	}
+
+	return bcNonce, nil
+}
+
+// ForceReloadNonce clears the nonce cache. This will force loading from BC next time.
+func (nt *DepotNonceTracker) ForceReloadNonce(chainID int64, account common.Address) {
+	nt.nonceLock.Lock()
+	defer nt.nonceLock.Unlock()
+	delete(nt.nonces, NewSender(account, chainID))
+}

--- a/transaction/sender.go
+++ b/transaction/sender.go
@@ -1,0 +1,15 @@
+package transaction
+
+import "github.com/ethereum/go-ethereum/common"
+
+type Sender struct {
+	Address common.Address
+	ChainID int64
+}
+
+func NewSender(addr common.Address, chain int64) Sender {
+	return Sender{
+		Address: addr,
+		ChainID: chain,
+	}
+}


### PR DESCRIPTION
* Introduced a new package `transaction`. Old package `transfer` is left for compatability, but will be deleted after everyone upgrades.
* New package `transaction` provides the same `gas` station package to interect with gas stations.
* New package contains new logic for a transaction delivery on the blockchain:
  * The base of all the logic is contained in the `delivery depot`. It works in a similar way as a real world delivery depot. Provided workers who package and track transactions and couriers which are able to deliver them, it's able to track transaction and delivery them.
  * A basic `courier` is provided which is able to deliver MYST and ETH transactions. The given courier doesn't have to be used or it can get wrapped by other couriers in services if needed.
  * Transactions are no longer tracked by hash, only by the senders nonce, if the nonce increased, we consider the transaction as accepted on BC.
  * Transaction object is not guaranteed to exist or to be correct for all sent out transaction, though for 99% of the cases it should be.
    *   Additional tracking logic could be added here to make sure our transaction object is always correct.
  * `Gas incrementing` information is no longer stored with each transaction, rather just the last gas used is kept.
  * `Nonce tracking` is done using stateful storage or BC if any gaps exist in the stateful storage.
  * All transactions that reach the delivery depot are considered to be possible to be transmitted to BC and will sit in the queue until they are. If enough unsendable transactions end up in the queue, it can get blocked forever.
  * The queue implementation is not ideal, but it's the easiest way to do it. While it might be a bit wasteful, if the queue size is relativity low it should be no problem and we can upgrade that part later.

Closes:
* https://github.com/mysteriumnetwork/node/issues/4475
* https://github.com/mysteriumnetwork/node/issues/4474