### PR TITLE
Dont depend on last transaction delivered for fillup

### DIFF
--- a/transaction/depot.go
+++ b/transaction/depot.go
@@ -257,7 +257,7 @@ func (d *Depot) handleTrackingRequired(td Delivery) error {
 	}
 
 	lastTime := td.UpdateUTC
-	if ld != nil {
+	if ld != nil && ld.UpdateUTC.After(lastTime) {
 		lastTime = ld.UpdateUTC
 	}
 


### PR DESCRIPTION
If transactions have a lot of time between them, we should check for that and dont increment if not needed.