### PR TITLE
Return the max of current gas and lastKnown*mult

### DIFF
--- a/transaction/gas_tracker.go
+++ b/transaction/gas_tracker.go
@@ -86,6 +86,16 @@ func (g *GasTracker) RecalculateDeliveryGas(chainID int64, lastKnownGas *big.Int
 		big.NewFloat(opts.Multiplier),
 		new(big.Float).SetInt(lastKnownGas),
 	).Int(nil)
+	recalculatedPrice, _ := g.ReceiveInitialGas(chainID)
+	if recalculatedPrice != nil {
+		if newGasPrice != nil {
+			if newGasPrice.Cmp(recalculatedPrice) < 0 {
+				return recalculatedPrice, nil
+			}
+		} else {
+			return recalculatedPrice, nil
+		}
+	}
 	if newGasPrice == nil {
 		return opts.PriceLimit, nil
 	}


### PR DESCRIPTION
If the lastKnown*mult is nil or is lower than the current gas price, we will return the current gas price. Will make gas recalculation more eficient.
Signed-off-by: Guillem Bonet <guillem@mysterium.network>