### PR TITLE
Fix a gas price check for resending

### DIFF
--- a/transaction/depot.go
+++ b/transaction/depot.go
@@ -283,7 +283,7 @@ func (d *Depot) handleTracking(td Delivery) error {
 		return err
 	}
 
-	if updated.GasPrice.Cmp(td.GasPrice) > 0 {
+	if updated.GasTip.Cmp(td.GasTip) > 0 {
 		_, err = d.sendOutTransaction(updated)
 		return err
 	}


### PR DESCRIPTION
Leftover bug from upgrade to EIP-1559. We no longer use gas price, we use gas tips.