### PR TITLE
Add registry to cache Hermes Callers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -54,6 +54,7 @@ type Blockchain struct {
 	ethClient EthClientGetter
 	bcTimeout time.Duration
 	nonceFunc nonceFunc
+	hcr       *HermesImplementationCallerRegistry
 }
 
 type nonceFunc func(ctx context.Context, account common.Address) (uint64, error)
@@ -66,6 +67,7 @@ func NewBlockchain(ethClient EthClientGetter, timeout time.Duration) *Blockchain
 		nonceFunc: func(ctx context.Context, account common.Address) (uint64, error) {
 			return ethClient.Client().PendingNonceAt(ctx, account)
 		},
+		hcr: NewHermesImplementationCallerRegistry(),
 	}
 }
 
@@ -92,7 +94,7 @@ func (bc *Blockchain) makeTransactOpts(ctx context.Context, rr *WriteRequest) (*
 
 // GetHermesFee fetches the hermes fee from blockchain
 func (bc *Blockchain) GetHermesFee(hermesAddress common.Address) (uint16, error) {
-	caller, err := bindings.NewHermesImplementationCaller(hermesAddress, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(hermesAddress, bc.ethClient.Client())
 	if err != nil {
 		return 0, errors.Wrap(err, "could not create hermes implementation caller")
 	}
@@ -112,7 +114,7 @@ func (bc *Blockchain) GetHermesFee(hermesAddress common.Address) (uint16, error)
 
 // CalculateHermesFee calls blockchain for calculation of hermes fee
 func (bc *Blockchain) CalculateHermesFee(hermesAddress common.Address, value *big.Int) (*big.Int, error) {
-	caller, err := bindings.NewHermesImplementationCaller(hermesAddress, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(hermesAddress, bc.ethClient.Client())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create hermes implementation caller")
 	}
@@ -203,7 +205,7 @@ func (bc *Blockchain) GetProviderChannel(hermesAddress common.Address, addressTo
 	if err != nil {
 		return ProviderChannel{}, errors.Wrap(err, "could not calculate provider channel address")
 	}
-	caller, err := bindings.NewHermesImplementationCaller(hermesAddress, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(hermesAddress, bc.ethClient.Client())
 	if err != nil {
 		return ProviderChannel{}, errors.Wrap(err, "could not create hermes caller")
 	}
@@ -224,7 +226,7 @@ func (bc *Blockchain) GetProvidersWithdrawalChannel(hermesAddress common.Address
 	if err != nil {
 		return ProviderChannel{}, errors.Wrap(err, "could not calculate provider channel address")
 	}
-	caller, err := bindings.NewHermesImplementationCaller(hermesAddress, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(hermesAddress, bc.ethClient.Client())
 	if err != nil {
 		return ProviderChannel{}, errors.Wrap(err, "could not create hermes caller")
 	}
@@ -727,7 +729,7 @@ func (bc *Blockchain) DecreaseProviderStake(req DecreaseProviderStakeRequest) (*
 
 // GetHermesOperator returns operator address of given hermes
 func (bc *Blockchain) GetHermesOperator(hermesID common.Address) (common.Address, error) {
-	caller, err := bindings.NewHermesImplementationCaller(hermesID, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(hermesID, bc.ethClient.Client())
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -743,7 +745,7 @@ func (bc *Blockchain) GetHermesOperator(hermesID common.Address) (common.Address
 
 // IsHermesActive determines if hermes is active or not.
 func (bc *Blockchain) IsHermesActive(hermesID common.Address) (bool, error) {
-	caller, err := bindings.NewHermesImplementationCaller(hermesID, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(hermesID, bc.ethClient.Client())
 	if err != nil {
 		return false, err
 	}
@@ -825,7 +827,7 @@ func (bc *Blockchain) GetLastRegistryNonce(registry common.Address) (*big.Int, e
 
 // GetProviderChannelByID returns the given provider channel information
 func (bc *Blockchain) GetProviderChannelByID(acc common.Address, chID []byte) (ProviderChannel, error) {
-	caller, err := bindings.NewHermesImplementationCaller(acc, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(acc, bc.ethClient.Client())
 	if err != nil {
 		return ProviderChannel{}, err
 	}
@@ -1031,7 +1033,7 @@ func (bc *Blockchain) GetHermes(registryID, hermesID common.Address) (Hermes, er
 
 // GetHermesRegistry returns the registry address of a given hermes.
 func (bc *Blockchain) GetHermesRegistry(hermesID common.Address) (common.Address, error) {
-	caller, err := bindings.NewHermesImplementationCaller(hermesID, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(hermesID, bc.ethClient.Client())
 	if err != nil {
 		return common.Address{}, err
 	}
@@ -1262,7 +1264,7 @@ func (r SettleWithBeneficiaryRequest) toEstimateOps() *bindings.EstimateOpts {
 
 // GetHermessAvailableBalance returns the balance that is available for hermes.
 func (bc *Blockchain) GetHermessAvailableBalance(hermesAddress common.Address) (*big.Int, error) {
-	caller, err := bindings.NewHermesImplementationCaller(hermesAddress, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(hermesAddress, bc.ethClient.Client())
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create hermes implementation caller")
 	}
@@ -1309,7 +1311,7 @@ func (bc *Blockchain) SettleWithBeneficiary(req SettleWithBeneficiaryRequest) (*
 
 // GetStakeThresholds returns the stake tresholds for the given hermes.
 func (bc *Blockchain) GetStakeThresholds(hermesID common.Address) (min, max *big.Int, err error) {
-	caller, err := bindings.NewHermesImplementationCaller(hermesID, bc.ethClient.Client())
+	caller, err := bc.hcr.Get(hermesID, bc.ethClient.Client())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -77,6 +77,7 @@ func NewBlockchainWithCustomNonceTracker(ethClient EthClientGetter, timeout time
 		ethClient: ethClient,
 		bcTimeout: timeout,
 		nonceFunc: nonceFunc,
+		hcr:       NewHermesImplementationCallerRegistry(),
 	}
 }
 

--- a/client/hermes_caller.go
+++ b/client/hermes_caller.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/mysteriumnetwork/payments/bindings"
+)
+
+type HermesImplementationCallerRegistry struct {
+	callers map[string]*bindings.HermesImplementationCaller
+}
+
+func NewHermesImplementationCallerRegistry() *HermesImplementationCallerRegistry {
+	return &HermesImplementationCallerRegistry{callers: make(map[string]*bindings.HermesImplementationCaller)}
+}
+func (h *HermesImplementationCallerRegistry) Get(hermesID common.Address, etherClient EtherClient) (*bindings.HermesImplementationCaller, error) {
+	if caller, exists := h.callers[hermesID.Hex()]; exists {
+		return caller, nil
+	}
+
+	caller, err := bindings.NewHermesImplementationCaller(hermesID, etherClient)
+	if err != nil {
+		return caller, err
+	}
+
+	h.callers[hermesID.Hex()] = caller
+
+	return caller, nil
+}


### PR DESCRIPTION
Main performance degradation happens not during RPC calls, but during instantiating new caller. Specifically during mapping ABI json metadata to ABI models (this json is quite big, around 16kb). There is no need to create new caller each time.

<img width="159" alt="Screenshot 2022-04-26 at 13 43 53" src="https://user-images.githubusercontent.com/2970001/165283140-e2c04f3f-91d4-46c5-8d03-36010dbb4cbf.png">
